### PR TITLE
fix: brainstorming UX overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "chrono",
  "futures",
  "mux",
+ "regex",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -638,6 +638,17 @@ pub async fn run_loop(swarm: Arc<tokio::sync::Mutex<SwarmOrchestrator>>) {
                 }
             }
 
+            // Question gating: skip all agents while a question is pending.
+            // The user needs to answer before agents can make progress.
+            // The loop will wake immediately via human_message_notify when
+            // the answer arrives.
+            {
+                let s = swarm.lock().await;
+                if s.has_pending_question() {
+                    continue;
+                }
+            }
+
             let did_work = run_agent_by_index(&swarm, i).await;
 
             if did_work {

--- a/crates/barnstormer-core/src/state.rs
+++ b/crates/barnstormer-core/src/state.rs
@@ -227,6 +227,7 @@ impl SpecState {
                 answer,
             } => {
                 self.pending_question = None;
+                self.canvas_content = None;
                 self.transcript.push(TranscriptMessage {
                     message_id: *question_id,
                     sender: "human".to_string(),

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -252,6 +252,7 @@ pub async fn import_spec(
         SpecPhase::Active => "active".to_string(),
     };
 
+    let has_pending_question = spec_state.pending_question.is_some();
     let canvas_content = spec_state.canvas_content.clone();
 
     let mut response = SpecViewTemplate {
@@ -262,6 +263,7 @@ pub async fn import_spec(
         phase,
         lanes,
         canvas_content,
+        has_pending_question,
     }
     .into_response();
 
@@ -431,6 +433,7 @@ pub async fn create_spec(
         SpecPhase::Active => "active".to_string(),
     };
 
+    let has_pending_question = spec_state.pending_question.is_some();
     let canvas_content = spec_state.canvas_content.clone();
 
     let mut response = SpecViewTemplate {
@@ -441,6 +444,7 @@ pub async fn create_spec(
         phase,
         lanes,
         canvas_content,
+        has_pending_question,
     }
     .into_response();
 
@@ -569,13 +573,32 @@ pub struct SpecViewTemplate {
     pub phase: String,
     pub lanes: Vec<LaneData>,
     pub canvas_content: Option<String>,
+    pub has_pending_question: bool,
+}
+
+/// Full-page spec view for direct navigation / page reload (non-HTMX requests).
+#[derive(Template, AskamaIntoResponse)]
+#[template(path = "spec_page.html")]
+pub struct SpecPageTemplate {
+    pub spec_id: String,
+    pub title: String,
+    pub one_liner: String,
+    pub goal: String,
+    pub phase: String,
+    pub lanes: Vec<LaneData>,
+    pub canvas_content: Option<String>,
+    pub has_pending_question: bool,
 }
 
 /// GET /web/specs/{id} - Render the spec compositor (command bar + canvas + chat rail).
+/// For HTMX requests returns the partial; for full page loads returns the complete shell.
 pub async fn spec_view(
     State(state): State<SharedState>,
     Path(id): Path<String>,
+    headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
+    let is_htmx = headers.get("HX-Request").is_some();
+
     let spec_id = match parse_spec_id(&id) {
         Ok(id) => id,
         Err(resp) => return *resp,
@@ -611,18 +634,34 @@ pub async fn spec_view(
         SpecPhase::Active => "active".to_string(),
     };
 
+    let has_pending_question = spec_state.pending_question.is_some();
     let canvas_content = spec_state.canvas_content.clone();
 
-    SpecViewTemplate {
-        spec_id: id,
-        title: core.title.clone(),
-        one_liner: core.one_liner.clone(),
-        goal: core.goal.clone(),
-        phase,
-        lanes,
-        canvas_content,
+    if is_htmx {
+        SpecViewTemplate {
+            spec_id: id,
+            title: core.title.clone(),
+            one_liner: core.one_liner.clone(),
+            goal: core.goal.clone(),
+            phase,
+            lanes,
+            canvas_content,
+            has_pending_question,
+        }
+        .into_response()
+    } else {
+        SpecPageTemplate {
+            spec_id: id,
+            title: core.title.clone(),
+            one_liner: core.one_liner.clone(),
+            goal: core.goal.clone(),
+            phase,
+            lanes,
+            canvas_content,
+            has_pending_question,
+        }
+        .into_response()
     }
-    .into_response()
 }
 
 /// Board partial template.
@@ -1158,7 +1197,7 @@ fn question_to_view_data(q: &barnstormer_core::UserQuestion) -> QuestionData {
             default,
         } => QuestionData::Boolean {
             question_id: question_id.to_string(),
-            question: question.clone(),
+            question: render_markdown(question),
             default: *default,
         },
         barnstormer_core::UserQuestion::MultipleChoice {
@@ -1168,7 +1207,7 @@ fn question_to_view_data(q: &barnstormer_core::UserQuestion) -> QuestionData {
             allow_multi,
         } => QuestionData::MultipleChoice {
             question_id: question_id.to_string(),
-            question: question.clone(),
+            question: render_markdown(question),
             choices: choices.clone(),
             allow_multi: *allow_multi,
         },
@@ -1179,7 +1218,7 @@ fn question_to_view_data(q: &barnstormer_core::UserQuestion) -> QuestionData {
             ..
         } => QuestionData::Freeform {
             question_id: question_id.to_string(),
-            question: question.clone(),
+            question: render_markdown(question),
             placeholder: placeholder.clone().unwrap_or_default(),
         },
     }
@@ -1197,7 +1236,7 @@ pub struct TranscriptQuery {
 /// user-controlled values rendered into script tags and HTMX attributes.
 fn sanitize_container_id(raw: &str) -> String {
     match raw {
-        "activity-transcript" | "chat-transcript" | "mission-ticker" | "canvas" | "chat-rail" => {
+        "activity-transcript" | "chat-transcript" | "mission-ticker" | "canvas" | "chat-rail" | "brainstorm-chat" => {
             raw.to_string()
         }
         _ => "chat-transcript".to_string(),
@@ -1300,7 +1339,7 @@ pub async fn activity_transcript(
         query.container_id.as_deref().unwrap_or("activity-transcript"),
     );
 
-    let is_chat = container_id == "chat-transcript";
+    let is_chat = container_id == "chat-transcript" || container_id == "brainstorm-chat";
 
     let mut transcript: Vec<TranscriptEntry> = spec_state
         .transcript
@@ -1377,7 +1416,7 @@ pub async fn chat_panel(
 
     let is_fullwidth = spec_state.phase == SpecPhase::Brainstorming;
     let container_id = if is_fullwidth {
-        "canvas".to_string()
+        "brainstorm-chat".to_string()
     } else {
         "chat-transcript".to_string()
     };
@@ -1789,6 +1828,30 @@ pub async fn answer_question(
     };
 
     // Events are persisted by the background broadcast subscriber.
+    // Drop actors lock before acquiring swarms to avoid deadlock.
+    drop(actors);
+
+    // Wake the agent loop so agents resume promptly after an answer.
+    {
+        let swarms = state.swarms.read().await;
+        if let Some(swarm_handle) = swarms.get(&spec_id) {
+            let swarm = swarm_handle.swarm.lock().await;
+            swarm.notify_human_message();
+        }
+    }
+
+    // Re-acquire actors to read transcript for response
+    let actors = state.actors.read().await;
+    let handle = match actors.get(&spec_id) {
+        Some(h) => h,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Html("<p class=\"error-msg\">Spec not found.</p>".to_string()),
+            )
+                .into_response();
+        }
+    };
 
     // Determine container_id from HX-Target header so the response replaces
     // the correct transcript container (activity panel vs chat tab).
@@ -1803,8 +1866,11 @@ pub async fn answer_question(
     // Return refreshed transcript partial
     let spec_state = handle.read_state().await;
 
-    let is_chat = container_id == "chat-transcript";
+    let is_chat = container_id == "chat-transcript" || container_id == "brainstorm-chat";
     let is_ticker = container_id == "mission-ticker";
+
+    // Read actual pending question from state instead of assuming None
+    let pending_question = spec_state.pending_question.as_ref().map(question_to_view_data);
 
     let mut transcript: Vec<TranscriptEntry> = spec_state
         .transcript
@@ -1829,7 +1895,7 @@ pub async fn answer_question(
         MissionTickerTemplate {
             spec_id: id,
             ticker_entries,
-            pending_question: None,
+            pending_question,
         }
         .into_response()
     } else if is_chat {
@@ -1837,7 +1903,7 @@ pub async fn answer_question(
             spec_id: id,
             container_id,
             transcript,
-            pending_question: None,
+            pending_question,
         }
         .into_response()
     } else {
@@ -1845,7 +1911,7 @@ pub async fn answer_question(
             spec_id: id,
             container_id,
             transcript,
-            pending_question: None,
+            pending_question,
         }
         .into_response()
     }
@@ -1957,7 +2023,7 @@ pub async fn chat(
     // Return refreshed transcript partial
     let spec_state = handle.read_state().await;
 
-    let is_chat = container_id == "chat-transcript";
+    let is_chat = container_id == "chat-transcript" || container_id == "brainstorm-chat";
     let is_ticker = container_id == "mission-ticker";
 
     let mut transcript: Vec<TranscriptEntry> = spec_state
@@ -3082,6 +3148,7 @@ mod tests {
             phase: "active".to_string(),
             lanes: vec![],
             canvas_content: None,
+            has_pending_question: false,
         };
         let rendered = tmpl.render().unwrap();
         // Command bar with title and subtitle
@@ -4983,13 +5050,23 @@ mod tests {
             *actors.keys().next().unwrap()
         };
 
-        // Send UpdateCanvas command to set canvas content
+        // Send UpdateCanvas command to set canvas content and a question so canvas is visible
         {
             let actors = state.actors.read().await;
             let handle = actors.get(&spec_id).unwrap();
             handle
                 .send_command(Command::UpdateCanvas {
                     content: "<p>Canvas pre-populated content</p>".to_string(),
+                })
+                .await
+                .unwrap();
+            handle
+                .send_command(Command::AskQuestion {
+                    question: barnstormer_core::UserQuestion::Boolean {
+                        question_id: ulid::Ulid::new(),
+                        question: "Test?".to_string(),
+                        default: Some(true),
+                    },
                 })
                 .await
                 .unwrap();

--- a/static/style.css
+++ b/static/style.css
@@ -119,6 +119,7 @@ html, body {
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    min-height: 0;
 }
 
 /* --- Command bar --- */
@@ -1278,6 +1279,9 @@ html, body {
     border-radius: var(--radius-xl);
     background: var(--bg-secondary);
     padding: 20px;
+    flex-shrink: 0;
+    overflow-y: auto;
+    max-height: 40%;
 }
 
 .chat-question-body {
@@ -1317,22 +1321,44 @@ html, body {
     transform: scale(0.99);
 }
 
-.chat-question-textarea {
-    width: 100%;
-    padding: 12px 16px;
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-xl);
-    color: var(--text-primary);
-    font-family: var(--font-body);
-    font-size: 14px;
-    resize: vertical;
-    margin-bottom: 8px;
+/* "Something else" escape hatch on choice questions */
+.chat-option-else {
+    border-style: dashed;
+    color: var(--text-muted);
 }
 
-.chat-question-textarea:focus {
+.chat-else-expand {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+/* Reuse .chat-input-row inside question cards */
+.chat-question-options .chat-input-row {
+    gap: 8px;
+}
+
+.chat-question-options .chat-input-row textarea {
+    flex: 1;
+    resize: none;
+    border-radius: var(--radius-xl);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 12px 16px;
+    font-size: 14px;
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    transition: all 0.15s;
+}
+
+.chat-question-options .chat-input-row textarea:focus {
     outline: none;
     border-color: var(--text-muted);
+}
+
+.chat-question-options .chat-input-row textarea::placeholder {
+    color: var(--text-muted);
+    opacity: 0.6;
 }
 
 /* Chat input area */
@@ -1561,11 +1587,12 @@ html, body {
   max-width: 720px;
   margin: 0 auto;
   padding: var(--spacing-md);
+  min-height: 0;
+  flex: 1;
 }
 
 .chat-fullwidth .chat-input-area {
-  max-width: 720px;
-  margin: 0 auto;
+  max-width: none;
 }
 
 /* Agent canvas container (hidden by default, wired up via canvas feature) */
@@ -1587,4 +1614,8 @@ html, body {
 [data-view="brainstorming"] .spec-body > .canvas {
   flex: 1;
   min-width: 300px;
+  overflow-y: hidden;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
 }

--- a/templates/partials/chat_panel.html
+++ b/templates/partials/chat_panel.html
@@ -11,9 +11,10 @@
         <form hx-post="/web/specs/{{ spec_id }}/chat"
               hx-target="#{{ container_id }}"
               hx-swap="outerHTML"
-              hx-on::after-request="this.reset()">
+              hx-on::after-request="this.reset()"
+              autocomplete="off">
             <div class="chat-input-row">
-                <textarea name="message" placeholder="Ask the agents anything..." rows="1" required></textarea>
+                <textarea name="message" placeholder="Ask the agents anything..." rows="1" required data-1p-ignore></textarea>
                 <button type="submit" class="btn btn-send" title="Send">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                 </button>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -97,7 +97,7 @@
               class="chat-question-options">
             <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
             <div class="chat-input-row">
-                <textarea name="answer" placeholder="{{ placeholder }}" rows="2" data-1p-ignore></textarea>
+                <textarea name="answer" placeholder="{{ placeholder }}" rows="2" data-1p-ignore required></textarea>
                 <button type="submit" class="btn btn-send" title="Send">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                 </button>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -55,10 +55,10 @@
             <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
             <button type="submit" name="answer" value="Yes" class="chat-option-btn">Yes</button>
             <button type="submit" name="answer" value="No" class="chat-option-btn">No</button>
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; this.style.display='none';">Something else&hellip;</button>
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer';">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore></textarea>
+                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore required></textarea>
                     <button type="submit" class="btn btn-send" title="Send">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                     </button>
@@ -77,10 +77,10 @@
             {% for choice in choices %}
             <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
             {% endfor %}
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; this.style.display='none';">Something else&hellip;</button>
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer';">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore></textarea>
+                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore required></textarea>
                     <button type="submit" class="btn btn-send" title="Send">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                     </button>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -46,37 +46,62 @@
         </div>
         {% match q %}
         {% when QuestionData::Boolean { question_id, question, default } %}
-        <div class="chat-question-body">{{ question }}</div>
+        <div class="chat-question-body">{{ question|safe }}</div>
         <form hx-post="/web/specs/{{ spec_id }}/answer"
               hx-target="#{{ container_id }}"
               hx-swap="outerHTML"
+              autocomplete="off"
               class="chat-question-options">
-            <input type="hidden" name="question_id" value="{{ question_id }}">
+            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
             <button type="submit" name="answer" value="Yes" class="chat-option-btn">Yes</button>
             <button type="submit" name="answer" value="No" class="chat-option-btn">No</button>
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; this.style.display='none';">Something else&hellip;</button>
+            <div class="chat-else-expand" style="display:none;">
+                <div class="chat-input-row">
+                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore></textarea>
+                    <button type="submit" class="btn btn-send" title="Send">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                    </button>
+                </div>
+            </div>
         </form>
 
         {% when QuestionData::MultipleChoice { question_id, question, choices, allow_multi } %}
-        <div class="chat-question-body">{{ question }}</div>
+        <div class="chat-question-body">{{ question|safe }}</div>
         <form hx-post="/web/specs/{{ spec_id }}/answer"
               hx-target="#{{ container_id }}"
               hx-swap="outerHTML"
+              autocomplete="off"
               class="chat-question-options">
-            <input type="hidden" name="question_id" value="{{ question_id }}">
+            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
             {% for choice in choices %}
             <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
             {% endfor %}
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; this.style.display='none';">Something else&hellip;</button>
+            <div class="chat-else-expand" style="display:none;">
+                <div class="chat-input-row">
+                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore></textarea>
+                    <button type="submit" class="btn btn-send" title="Send">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                    </button>
+                </div>
+            </div>
         </form>
 
         {% when QuestionData::Freeform { question_id, question, placeholder } %}
-        <div class="chat-question-body">{{ question }}</div>
+        <div class="chat-question-body">{{ question|safe }}</div>
         <form hx-post="/web/specs/{{ spec_id }}/answer"
               hx-target="#{{ container_id }}"
               hx-swap="outerHTML"
+              autocomplete="off"
               class="chat-question-options">
-            <input type="hidden" name="question_id" value="{{ question_id }}">
-            <textarea name="answer" placeholder="{{ placeholder }}" rows="2" class="chat-question-textarea"></textarea>
-            <button type="submit" class="chat-option-btn">Submit</button>
+            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
+            <div class="chat-input-row">
+                <textarea name="answer" placeholder="{{ placeholder }}" rows="2" data-1p-ignore></textarea>
+                <button type="submit" class="btn btn-send" title="Send">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                </button>
+            </div>
         </form>
         {% endmatch %}
     </div>
@@ -86,7 +111,36 @@
 
 <script>
     (function() {
-        var feed = document.getElementById('{{ container_id }}-feed');
+        var feedId = '{{ container_id }}-feed';
+        var feed = document.getElementById(feedId);
         if (feed) feed.scrollTop = feed.scrollHeight;
+
+        // Save scroll position before swap, restore after
+        document.body.addEventListener('htmx:beforeSwap', function(evt) {
+            if (evt.detail.target && evt.detail.target.id === '{{ container_id }}') {
+                var f = document.getElementById(feedId);
+                if (f) {
+                    // Store whether user was scrolled to bottom
+                    var atBottom = (f.scrollHeight - f.scrollTop - f.clientHeight) < 50;
+                    evt.detail.target._wasAtBottom = atBottom;
+                    evt.detail.target._scrollTop = f.scrollTop;
+                }
+            }
+        });
+
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            if (evt.detail.target && evt.detail.target.id === '{{ container_id }}') {
+                var f = document.getElementById(feedId);
+                if (!f) return;
+                // If user was at bottom (or close), scroll to new bottom
+                // Otherwise restore their scroll position
+                var prev = evt.detail.target;
+                if (prev._wasAtBottom !== false) {
+                    f.scrollTop = f.scrollHeight;
+                } else if (prev._scrollTop !== undefined) {
+                    f.scrollTop = prev._scrollTop;
+                }
+            }
+        });
     })();
 </script>

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -31,12 +31,16 @@
           hx-get="/web/specs/{{ spec_id }}/chat-panel"
           hx-trigger="load" hx-swap="innerHTML">
     </main>
+    {% if has_pending_question %}
     {% match canvas_content %}
     {% when Some with (content) %}
     <div id="agent-canvas" style="display:block;">{{ content|safe }}</div>
     {% when None %}
     <div id="agent-canvas" style="display:none;"></div>
     {% endmatch %}
+    {% else %}
+    <div id="agent-canvas" style="display:none;"></div>
+    {% endif %}
 </div>
 
 </div>
@@ -72,6 +76,15 @@
                     canvas.innerHTML = content;
                     canvas.style.display = 'block';
                 } else {
+                    canvas.innerHTML = '';
+                    canvas.style.display = 'none';
+                }
+            });
+
+            // Clear the agent canvas when a question is answered (stale visual)
+            compositor.addEventListener('sse:question_answered', function() {
+                var canvas = document.getElementById('agent-canvas');
+                if (canvas) {
                     canvas.innerHTML = '';
                     canvas.style.display = 'none';
                 }

--- a/templates/spec_page.html
+++ b/templates/spec_page.html
@@ -1,0 +1,30 @@
+{# ABOUTME: Full-page wrapper for spec view, used on direct navigation / page reload. #}
+{# ABOUTME: Extends base.html and embeds the spec compositor partial in the workspace block. #}
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block nav %}
+<div class="rail-header">
+    <span>Your specs</span>
+</div>
+<div class="spec-list" id="spec-list" hx-get="/web/specs" hx-trigger="load" hx-swap="innerHTML">
+    <p class="loading">Loading specs...</p>
+</div>
+<div id="provider-status" hx-get="/web/provider-status" hx-trigger="load" hx-swap="innerHTML">
+</div>
+<div class="rail-footer">
+    <button class="new-spec-btn" hx-get="/web/specs/new" hx-target="#workspace" hx-swap="innerHTML">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        New spec
+    </button>
+    <button class="new-spec-btn" hx-get="/web/specs/import" hx-target="#workspace" hx-swap="innerHTML" style="margin-top: 4px;">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Import
+    </button>
+</div>
+{% endblock %}
+
+{% block workspace %}
+{% include "partials/spec_view.html" %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- **Question gating**: Agents go silent while a question is pending instead of spamming "still waiting for input." Resume immediately when user answers.
- **Course correction**: "Something else..." option on all boolean and multiple choice questions — expands into freeform textarea so users can redirect when none of the canned options fit.
- **Markdown rendering**: Question text now renders bold, lists, etc. instead of raw `**markdown**`.
- **Input standardization**: Freeform answers use the same textarea + round send button component as main chat input.
- **1Password fix**: `autocomplete="off"` and `data-1p-ignore` on all question/chat forms to stop identity save prompts.
- **Layout fixes**: Brainstorming container ID collision (brainstorm-chat vs canvas), stale canvas cleanup on answer, full-page navigation support, chat-fullwidth input stretching.

## Test plan
- [ ] Start agents with a pending question — verify no "still waiting" spam
- [ ] Answer a question — verify agents resume immediately
- [ ] Click "Something else..." on a multiple choice question — verify textarea appears and submits
- [ ] Click Yes/No on a boolean question — verify it submits (no textarea name conflict)
- [ ] Check that 1Password does not prompt to save after answering questions
- [ ] Verify markdown renders in question body (bold, bullet lists)
- [ ] Direct navigate to `/web/specs/{id}` — verify full page loads
- [ ] `cargo test --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now pause while a user question is pending.
  * Full-page spec view added for non-HTMX page loads.
  * New "brainstorm" chat container mode for fullwidth brainstorming.

* **Bug Fixes**
  * Canvas now clears when questions are answered.
  * Chat actions reliably wake agents and avoid actor lock issues.

* **UI/UX Improvements**
  * "Something else" answer flow, markdown-rendered questions, improved chat layout, scroll-preservation, and autocomplete controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->