### PR TITLE
feat: phase wayfinding, mobile responsive, streaming activity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ cargo run -- start --no-open
 
 # Check if running
 cargo run -- status
+
+# Dev mode: auto-rebuild and restart on file changes (requires cargo-watch)
+cargo watch -x 'run -- start --no-open' -w crates -w templates -w static -w src
 ```
 
 ## Architecture

--- a/crates/barnstormer-agent/src/context.rs
+++ b/crates/barnstormer-agent/src/context.rs
@@ -224,6 +224,12 @@ fn describe_event_payload(payload: &EventPayload) -> String {
                 "canvas updated with new content".to_string()
             }
         }
+        EventPayload::StreamingDelta { agent_id, .. } => {
+            format!("streaming delta from {}", agent_id)
+        }
+        EventPayload::StreamingToolActivity { agent_id, activity } => {
+            format!("{}: {}", agent_id, activity)
+        }
     }
 }
 

--- a/crates/barnstormer-agent/src/lib.rs
+++ b/crates/barnstormer-agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod client;
 pub mod context;
 pub mod import;
 pub mod mux_tools;
+pub mod streaming_hook;
 pub mod swarm;
 pub mod testing;
 

--- a/crates/barnstormer-agent/src/mux_tools/propose_transition.rs
+++ b/crates/barnstormer-agent/src/mux_tools/propose_transition.rs
@@ -1,4 +1,4 @@
-// ABOUTME: Tool that lets the Manager propose transitioning from brainstorming to active mode.
+// ABOUTME: Tool that lets the Manager propose transitioning to the next spec phase.
 // ABOUTME: Reuses existing AskQuestion infrastructure with swarm-level answer-watching.
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,6 +11,7 @@ use ulid::Ulid;
 
 use barnstormer_core::actor::SpecActorHandle;
 use barnstormer_core::command::Command;
+use barnstormer_core::state::SpecPhase;
 use barnstormer_core::transcript::UserQuestion;
 
 #[derive(Clone)]
@@ -27,7 +28,7 @@ impl Tool for ProposeTransitionTool {
     }
 
     fn description(&self) -> &str {
-        "Propose transitioning from brainstorming to active mode. Summarize what you've learned and ask the user if they're ready to build the spec."
+        "Propose transitioning to the next phase of the spec. Summarize progress so far and ask the user if they're ready to move on."
     }
 
     fn schema(&self) -> serde_json::Value {
@@ -44,6 +45,14 @@ impl Tool for ProposeTransitionTool {
     }
 
     async fn execute(&self, params: serde_json::Value) -> Result<ToolResult, anyhow::Error> {
+        // Check current phase to determine appropriate question text
+        let current_phase = self.actor.read_state().await.phase.clone();
+        if current_phase == SpecPhase::Complete {
+            return Ok(ToolResult::text(
+                "The spec is already in the Complete phase. No further transitions are available.",
+            ));
+        }
+
         if self
             .question_pending
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -62,10 +71,20 @@ impl Tool for ProposeTransitionTool {
             }
         };
 
+        let question_text = match current_phase {
+            SpecPhase::Brainstorming => {
+                format!("{}\n\nReady to start organizing the spec?", summary)
+            }
+            SpecPhase::Refining => {
+                format!("{}\n\nThe spec looks complete. Ready to finalize?", summary)
+            }
+            SpecPhase::Complete => unreachable!(),
+        };
+
         let question_id = Ulid::new();
         let question = UserQuestion::Boolean {
             question_id,
-            question: format!("{}\n\nReady to move on and build the spec?", summary),
+            question: question_text,
             default: Some(true),
         };
 
@@ -266,6 +285,126 @@ mod tests {
         assert!(
             !question_pending.load(Ordering::SeqCst),
             "question_pending should be reset after parameter validation failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn propose_transition_brainstorming_asks_about_organizing() {
+        let (_id, handle) = make_test_actor();
+        let handle = Arc::new(handle);
+        handle
+            .send_command(Command::CreateSpec {
+                title: "Test".to_string(),
+                one_liner: "t".to_string(),
+                goal: "g".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let tool = ProposeTransitionTool {
+            actor: handle.clone(),
+            question_pending: Arc::new(AtomicBool::new(false)),
+            pending_transition_question: Arc::new(Mutex::new(None)),
+        };
+
+        tool.execute(json!({"summary": "Brainstorming complete."}))
+            .await
+            .unwrap();
+
+        let state = handle.read_state().await;
+        if let Some(UserQuestion::Boolean { question, .. }) = &state.pending_question {
+            assert!(
+                question.contains("organizing the spec"),
+                "brainstorming question should mention organizing: {}",
+                question
+            );
+        } else {
+            panic!("expected Boolean question");
+        }
+    }
+
+    #[tokio::test]
+    async fn propose_transition_refining_asks_about_finalizing() {
+        let (_id, handle) = make_test_actor();
+        let handle = Arc::new(handle);
+        handle
+            .send_command(Command::CreateSpec {
+                title: "Test".to_string(),
+                one_liner: "t".to_string(),
+                goal: "g".to_string(),
+            })
+            .await
+            .unwrap();
+        // Move to Refining phase
+        handle
+            .send_command(Command::TransitionPhase {
+                target: SpecPhase::Refining,
+            })
+            .await
+            .unwrap();
+
+        let tool = ProposeTransitionTool {
+            actor: handle.clone(),
+            question_pending: Arc::new(AtomicBool::new(false)),
+            pending_transition_question: Arc::new(Mutex::new(None)),
+        };
+
+        tool.execute(json!({"summary": "Spec is refined."}))
+            .await
+            .unwrap();
+
+        let state = handle.read_state().await;
+        if let Some(UserQuestion::Boolean { question, .. }) = &state.pending_question {
+            assert!(
+                question.contains("Ready to finalize"),
+                "refining question should mention finalizing: {}",
+                question
+            );
+        } else {
+            panic!("expected Boolean question");
+        }
+    }
+
+    #[tokio::test]
+    async fn propose_transition_complete_phase_returns_noop() {
+        let (_id, handle) = make_test_actor();
+        let handle = Arc::new(handle);
+        handle
+            .send_command(Command::CreateSpec {
+                title: "Test".to_string(),
+                one_liner: "t".to_string(),
+                goal: "g".to_string(),
+            })
+            .await
+            .unwrap();
+        // Move to Refining, then Complete
+        handle
+            .send_command(Command::TransitionPhase {
+                target: SpecPhase::Refining,
+            })
+            .await
+            .unwrap();
+        handle
+            .send_command(Command::TransitionPhase {
+                target: SpecPhase::Complete,
+            })
+            .await
+            .unwrap();
+
+        let tool = ProposeTransitionTool {
+            actor: handle.clone(),
+            question_pending: Arc::new(AtomicBool::new(false)),
+            pending_transition_question: Arc::new(Mutex::new(None)),
+        };
+
+        let result = tool
+            .execute(json!({"summary": "Already done."}))
+            .await
+            .unwrap();
+        assert!(
+            result.content.contains("already in the Complete phase"),
+            "should indicate no transitions available: {}",
+            result.content
         );
     }
 }

--- a/crates/barnstormer-agent/src/mux_tools/show_canvas.rs
+++ b/crates/barnstormer-agent/src/mux_tools/show_canvas.rs
@@ -217,7 +217,7 @@ mod tests {
             .unwrap();
         handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();

--- a/crates/barnstormer-agent/src/streaming_hook.rs
+++ b/crates/barnstormer-agent/src/streaming_hook.rs
@@ -1,0 +1,243 @@
+// ABOUTME: Mux Hook implementation that forwards LLM streaming events to the spec actor.
+// ABOUTME: Bridges StreamDelta and tool-use callbacks into ephemeral broadcast events.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use barnstormer_core::{Command, SpecActorHandle};
+use mux::hook::{Hook, HookAction, HookEvent};
+
+/// A mux Hook that forwards streaming events from the LLM agent loop into
+/// the barnstormer event system via the SpecActorHandle.
+///
+/// Manager agents stream text deltas to the UI. All agents (manager and worker)
+/// stream tool activity notifications so users can see what the agent is doing.
+pub struct StreamingHook {
+    actor: Arc<SpecActorHandle>,
+    agent_id: String,
+    is_manager: bool,
+}
+
+impl StreamingHook {
+    /// Create a new StreamingHook.
+    ///
+    /// - `actor`: handle to the spec actor for sending commands
+    /// - `agent_id`: identifier for the agent producing events
+    /// - `is_manager`: if true, text deltas are forwarded; workers skip text streaming
+    pub fn new(actor: Arc<SpecActorHandle>, agent_id: String, is_manager: bool) -> Self {
+        Self {
+            actor,
+            agent_id,
+            is_manager,
+        }
+    }
+}
+
+#[async_trait]
+impl Hook for StreamingHook {
+    fn accepts(&self, event: &HookEvent) -> bool {
+        matches!(
+            event,
+            HookEvent::StreamDelta { .. }
+                | HookEvent::PostToolUse { .. }
+                | HookEvent::Iteration { .. }
+        )
+    }
+
+    async fn on_event(&self, event: &HookEvent) -> Result<HookAction, anyhow::Error> {
+        match event {
+            HookEvent::StreamDelta { text, .. } if self.is_manager => {
+                let _ = self
+                    .actor
+                    .send_command(Command::StreamDelta {
+                        agent_id: self.agent_id.clone(),
+                        text: text.clone(),
+                    })
+                    .await;
+            }
+
+            HookEvent::StreamDelta { .. } => {
+                // Workers don't stream text deltas
+            }
+
+            HookEvent::PostToolUse {
+                tool_name, input, ..
+            } => {
+                let title = input
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let activity = if title.is_empty() {
+                    tool_name.clone()
+                } else {
+                    format!("{tool_name}: {title}")
+                };
+                let _ = self
+                    .actor
+                    .send_command(Command::StreamToolActivity {
+                        agent_id: self.agent_id.clone(),
+                        activity,
+                    })
+                    .await;
+            }
+
+            HookEvent::Iteration { .. } => {
+                let _ = self
+                    .actor
+                    .send_command(Command::StreamToolActivity {
+                        agent_id: self.agent_id.clone(),
+                        activity: "thinking...".to_string(),
+                    })
+                    .await;
+            }
+
+            _ => {}
+        }
+
+        Ok(HookAction::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use barnstormer_core::{SpecState, spawn};
+    use mux::tool::ToolResult;
+    use ulid::Ulid;
+
+    /// Helper: create a SpecActorHandle wrapped in Arc plus a broadcast receiver.
+    fn setup_actor() -> (Arc<SpecActorHandle>, tokio::sync::broadcast::Receiver<barnstormer_core::Event>) {
+        let handle = spawn(Ulid::new(), SpecState::new());
+        let rx = handle.subscribe();
+        (Arc::new(handle), rx)
+    }
+
+    #[tokio::test]
+    async fn hook_sends_streaming_delta_for_manager() {
+        let (actor, mut rx) = setup_actor();
+        let hook = StreamingHook::new(actor, "manager-1".to_string(), true);
+
+        let event = HookEvent::StreamDelta {
+            agent_id: "manager-1".to_string(),
+            text: "Hello".to_string(),
+        };
+
+        let action = hook.on_event(&event).await.unwrap();
+        assert!(matches!(action, HookAction::Continue));
+
+        let broadcast = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            rx.recv(),
+        )
+        .await
+        .expect("should receive broadcast within timeout")
+        .expect("broadcast recv should succeed");
+
+        match &broadcast.payload {
+            barnstormer_core::EventPayload::StreamingDelta { agent_id, text } => {
+                assert_eq!(agent_id, "manager-1");
+                assert_eq!(text, "Hello");
+            }
+            other => panic!("expected StreamingDelta, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_ignores_streaming_delta_for_non_manager() {
+        let (actor, mut rx) = setup_actor();
+        let hook = StreamingHook::new(actor, "worker-1".to_string(), false);
+
+        let event = HookEvent::StreamDelta {
+            agent_id: "worker-1".to_string(),
+            text: "should be ignored".to_string(),
+        };
+
+        let action = hook.on_event(&event).await.unwrap();
+        assert!(matches!(action, HookAction::Continue));
+
+        // No broadcast should have been sent
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            rx.recv(),
+        )
+        .await;
+        assert!(result.is_err(), "expected timeout (no broadcast), but got a message");
+    }
+
+    #[tokio::test]
+    async fn hook_sends_tool_activity_for_any_agent() {
+        let (actor, mut rx) = setup_actor();
+        // Use is_manager=false to show tool activity works for workers too
+        let hook = StreamingHook::new(actor, "worker-1".to_string(), false);
+
+        let event = HookEvent::PostToolUse {
+            tool_name: "create_card".to_string(),
+            tool_use_id: "toolu_123".to_string(),
+            input: serde_json::json!({ "title": "Auth Flow" }),
+            result: ToolResult::text("ok"),
+        };
+
+        let action = hook.on_event(&event).await.unwrap();
+        assert!(matches!(action, HookAction::Continue));
+
+        let broadcast = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            rx.recv(),
+        )
+        .await
+        .expect("should receive broadcast within timeout")
+        .expect("broadcast recv should succeed");
+
+        match &broadcast.payload {
+            barnstormer_core::EventPayload::StreamingToolActivity { agent_id, activity } => {
+                assert_eq!(agent_id, "worker-1");
+                assert!(activity.contains("create_card"), "activity should contain tool name");
+                assert!(activity.contains("Auth Flow"), "activity should contain title");
+            }
+            other => panic!("expected StreamingToolActivity, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_sends_thinking_on_iteration() {
+        let (actor, mut rx) = setup_actor();
+        let hook = StreamingHook::new(actor, "manager-1".to_string(), true);
+
+        let event = HookEvent::Iteration {
+            agent_id: "manager-1".to_string(),
+            iteration: 1,
+        };
+
+        let action = hook.on_event(&event).await.unwrap();
+        assert!(matches!(action, HookAction::Continue));
+
+        let broadcast = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            rx.recv(),
+        )
+        .await
+        .expect("should receive broadcast within timeout")
+        .expect("broadcast recv should succeed");
+
+        match &broadcast.payload {
+            barnstormer_core::EventPayload::StreamingToolActivity { agent_id, activity } => {
+                assert_eq!(agent_id, "manager-1");
+                assert!(activity.contains("thinking"), "activity should contain 'thinking'");
+            }
+            other => panic!("expected StreamingToolActivity, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_rejects_irrelevant_events() {
+        let (actor, _rx) = setup_actor();
+        let hook = StreamingHook::new(actor, "manager-1".to_string(), true);
+
+        let event = HookEvent::AgentStart {
+            agent_id: "manager-1".to_string(),
+            task: "brainstorm".to_string(),
+        };
+
+        assert!(!hook.accepts(&event), "accepts() should return false for AgentStart");
+    }
+}

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -10,7 +10,10 @@ use tracing;
 use ulid::Ulid;
 
 use mux::agent::{AgentDefinition, SubAgent};
+use mux::hook::HookRegistry;
 use mux::llm::LlmClient;
+
+use crate::streaming_hook::StreamingHook;
 
 use std::collections::HashMap;
 
@@ -385,13 +388,19 @@ impl SwarmOrchestrator {
         )
         .await;
 
+        let is_manager = runner.role == AgentRole::Manager;
+
         // Create agent definition with role-specific system prompt + tool guide
-        let definition = AgentDefinition::new(
+        let mut definition = AgentDefinition::new(
             runner.role.label(),
             full_system_prompt(&runner.role, &runner.agent_id, phase),
         )
         .model(model)
         .max_iterations(10);
+
+        if is_manager {
+            definition = definition.streaming(true);
+        }
 
         // Create a fresh SubAgent
         let mut sub_agent = SubAgent::new(
@@ -399,6 +408,16 @@ impl SwarmOrchestrator {
             Arc::clone(client),
             registry,
         );
+
+        // Attach streaming hook for real-time event forwarding
+        let hook_registry = Arc::new(HookRegistry::new());
+        let hook = StreamingHook::new(
+            Arc::clone(actor),
+            runner.agent_id.clone(),
+            is_manager,
+        );
+        hook_registry.register(hook).await;
+        sub_agent = sub_agent.with_hooks(hook_registry);
 
         // Build task prompt from context
         let task_prompt = build_task_prompt(&runner.context);

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -663,7 +663,7 @@ pub async fn run_loop(swarm: Arc<tokio::sync::Mutex<SwarmOrchestrator>>) {
                 let s = swarm.lock().await;
                 if should_transition_on_answer(&s.pending_transition_question, *question_id, answer) {
                     let _ = s.actor.send_command(Command::TransitionPhase {
-                        target: SpecPhase::Active,
+                        target: SpecPhase::Refining,
                     }).await;
                 }
             }
@@ -853,7 +853,7 @@ mod tests {
             &pending_transition,
             &client,
             "stub-model",
-            &SpecPhase::Active,
+            &SpecPhase::Refining,
         )
         .await;
 
@@ -1332,17 +1332,17 @@ mod tests {
             })
             .await
             .unwrap();
-        // Transition to Active
+        // Transition to Refining
         handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();
 
         {
             let state = handle.read_state().await;
-            assert_eq!(state.phase, SpecPhase::Active);
+            assert_eq!(state.phase, SpecPhase::Refining);
         }
 
         let agents = vec![
@@ -1409,15 +1409,15 @@ mod tests {
     }
 
     #[test]
-    fn manager_gets_standard_prompt_in_active() {
-        let prompt = full_system_prompt(&AgentRole::Manager, "agent-123", &SpecPhase::Active);
+    fn manager_gets_standard_prompt_in_refining() {
+        let prompt = full_system_prompt(&AgentRole::Manager, "agent-123", &SpecPhase::Refining);
         assert!(!prompt.contains("ONE question at a time"));
         assert!(prompt.contains("manager agent for a product specification"));
     }
 
     #[test]
     fn non_manager_gets_same_prompt_regardless_of_phase() {
-        let active = full_system_prompt(&AgentRole::Brainstormer, "agent-123", &SpecPhase::Active);
+        let active = full_system_prompt(&AgentRole::Brainstormer, "agent-123", &SpecPhase::Refining);
         let brainstorming = full_system_prompt(&AgentRole::Brainstormer, "agent-123", &SpecPhase::Brainstorming);
         assert_eq!(active, brainstorming);
     }

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -427,10 +427,19 @@ impl SwarmOrchestrator {
                     "agent step failed"
                 );
                 // Show a sanitized, user-friendly message in the transcript
-                // without exposing internal error details.
+                // with a short error summary for debugging context.
+                let error_text = e.to_string();
+                let error_summary: String = error_text
+                    .chars()
+                    .filter(|c| *c != '\n' && *c != '\r')
+                    .take(100)
+                    .collect::<String>()
+                    .trim()
+                    .to_string();
                 let user_msg = format!(
-                    "[{}] encountered an issue and will retry on the next cycle.",
+                    "[{}] encountered an issue ({}). Will retry next cycle.",
                     runner.role.label(),
+                    error_summary,
                 );
                 let _ = actor
                     .send_command(Command::AppendTranscript {

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -561,6 +561,21 @@ async fn run_agent_by_index(
     )
     .await;
 
+    // Skip the LLM call if nothing has changed since the last step.
+    // The agent only needs to run when there are new events to react to.
+    // First run (last_event_seen == 0) always proceeds.
+    if runner.context.recent_events.is_empty() && runner.context.last_event_seen > 0 {
+        tracing::debug!(
+            agent = %runner.agent_id,
+            "no new events, skipping agent step"
+        );
+        // Put the runner back without calling the LLM
+        let mut s = swarm.lock().await;
+        s.agents[index] = Some(runner);
+        s.event_receivers[index] = event_rx;
+        return false;
+    }
+
     let phase = actor_ref.read_state().await.phase.clone();
 
     let did_work = SwarmOrchestrator::run_agent_step(

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -662,8 +662,14 @@ pub async fn run_loop(swarm: Arc<tokio::sync::Mutex<SwarmOrchestrator>>) {
             if let EventPayload::QuestionAnswered { question_id, answer } = &event.payload {
                 let s = swarm.lock().await;
                 if should_transition_on_answer(&s.pending_transition_question, *question_id, answer) {
+                    let current_phase = s.actor.read_state().await.phase.clone();
+                    let target = match current_phase {
+                        SpecPhase::Brainstorming => SpecPhase::Refining,
+                        SpecPhase::Refining => SpecPhase::Complete,
+                        SpecPhase::Complete => continue,
+                    };
                     let _ = s.actor.send_command(Command::TransitionPhase {
-                        target: SpecPhase::Refining,
+                        target,
                     }).await;
                 }
             }

--- a/crates/barnstormer-core/src/actor.rs
+++ b/crates/barnstormer-core/src/actor.rs
@@ -701,14 +701,14 @@ mod tests {
 
         let events = handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();
         assert_eq!(events.len(), 1);
         match &events[0].payload {
             EventPayload::PhaseTransitioned { phase } => {
-                assert_eq!(*phase, SpecPhase::Active);
+                assert_eq!(*phase, SpecPhase::Refining);
             }
             _ => panic!("wrong event"),
         }
@@ -727,18 +727,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Brainstorming -> Active
+        // Brainstorming -> Refining
         handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();
 
-        // Active -> Active should fail
+        // Refining -> Refining should fail
         let err = handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap_err();
@@ -746,7 +746,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transition_phase_brainstorming_active_brainstorming() {
+    async fn transition_phase_brainstorming_refining_brainstorming() {
         let spec_id = Ulid::new();
         let handle = spawn(spec_id, SpecState::new());
         handle
@@ -758,10 +758,10 @@ mod tests {
             .await
             .unwrap();
 
-        // Brainstorming -> Active -> Brainstorming
+        // Brainstorming -> Refining -> Brainstorming
         handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();

--- a/crates/barnstormer-core/src/actor.rs
+++ b/crates/barnstormer-core/src/actor.rs
@@ -328,6 +328,14 @@ impl SpecActor {
                 vec![EventPayload::CanvasUpdated { content }]
             }
 
+            Command::StreamDelta { agent_id, text } => {
+                vec![EventPayload::StreamingDelta { agent_id, text }]
+            }
+
+            Command::StreamToolActivity { agent_id, activity } => {
+                vec![EventPayload::StreamingToolActivity { agent_id, activity }]
+            }
+
             Command::Undo => {
                 if state.undo_stack.is_empty() {
                     return Err(ActorError::NothingToUndo);
@@ -773,6 +781,36 @@ mod tests {
             .unwrap();
         let state = handle.read_state().await;
         assert_eq!(state.phase, SpecPhase::Brainstorming);
+    }
+
+    #[tokio::test]
+    async fn actor_broadcasts_streaming_delta() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+        let mut rx = handle.subscribe();
+
+        let events = handle
+            .send_command(Command::StreamDelta {
+                agent_id: "manager-1".to_string(),
+                text: "Hi".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 1);
+        match &events[0].payload {
+            EventPayload::StreamingDelta { agent_id, text } => {
+                assert_eq!(agent_id, "manager-1");
+                assert_eq!(text, "Hi");
+            }
+            _ => panic!("expected StreamingDelta"),
+        }
+
+        let broadcast = rx.recv().await.unwrap();
+        match &broadcast.payload {
+            EventPayload::StreamingDelta { .. } => {}
+            _ => panic!("expected StreamingDelta broadcast"),
+        }
     }
 
     #[tokio::test]

--- a/crates/barnstormer-core/src/actor.rs
+++ b/crates/barnstormer-core/src/actor.rs
@@ -357,8 +357,16 @@ impl SpecActor {
         let events = payloads
             .into_iter()
             .map(|payload| {
-                let event_id = self.next_event_id;
-                self.next_event_id += 1;
+                // Ephemeral events (streaming deltas, tool activity) get event_id 0
+                // and do not consume a monotonic ID. This avoids gaps in the
+                // persisted JSONL log since ephemeral events are never written.
+                let event_id = if payload.is_ephemeral() {
+                    0
+                } else {
+                    let id = self.next_event_id;
+                    self.next_event_id += 1;
+                    id
+                };
                 Event {
                     event_id,
                     spec_id: self.spec_id,
@@ -811,6 +819,42 @@ mod tests {
             EventPayload::StreamingDelta { .. } => {}
             _ => panic!("expected StreamingDelta broadcast"),
         }
+    }
+
+    #[tokio::test]
+    async fn ephemeral_events_get_zero_event_id() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+
+        // Create spec first (uses event IDs 1 and 2)
+        handle
+            .send_command(Command::CreateSpec {
+                title: "Ephemeral Test".to_string(),
+                one_liner: "t".to_string(),
+                goal: "g".to_string(),
+            })
+            .await
+            .unwrap();
+
+        // Send a streaming delta — ephemeral, should get event_id 0
+        let events = handle
+            .send_command(Command::StreamDelta {
+                agent_id: "manager-1".to_string(),
+                text: "Hello".to_string(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_id, 0, "ephemeral events should get event_id 0");
+
+        // Send a durable event — should get event_id 3 (no gap from ephemeral)
+        let events = handle
+            .send_command(Command::UpdateCanvas {
+                content: "<p>test</p>".to_string(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(events[0].event_id, 3, "durable event ID should not be affected by ephemeral events");
     }
 
     #[tokio::test]

--- a/crates/barnstormer-core/src/command.rs
+++ b/crates/barnstormer-core/src/command.rs
@@ -165,6 +165,14 @@ mod tests {
                 content: "<h1>Hello</h1>".to_string(),
             },
             Command::Undo,
+            Command::StreamDelta {
+                agent_id: "manager-1".to_string(),
+                text: "token".to_string(),
+            },
+            Command::StreamToolActivity {
+                agent_id: "brainstormer-1".to_string(),
+                activity: "creating card".to_string(),
+            },
         ];
 
         for cmd in &commands {

--- a/crates/barnstormer-core/src/command.rs
+++ b/crates/barnstormer-core/src/command.rs
@@ -151,7 +151,7 @@ mod tests {
                 diff_summary: "Added cards".to_string(),
             },
             Command::TransitionPhase {
-                target: crate::state::SpecPhase::Active,
+                target: crate::state::SpecPhase::Refining,
             },
             Command::UpdateCanvas {
                 content: "<h1>Hello</h1>".to_string(),
@@ -171,15 +171,15 @@ mod tests {
     #[test]
     fn transition_phase_round_trip() {
         let cmd = Command::TransitionPhase {
-            target: crate::state::SpecPhase::Active,
+            target: crate::state::SpecPhase::Refining,
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"TransitionPhase\""));
-        assert!(json.contains("\"active\""));
+        assert!(json.contains("\"refining\""));
         let back: Command = serde_json::from_str(&json).unwrap();
         match back {
             Command::TransitionPhase { target } => {
-                assert_eq!(target, crate::state::SpecPhase::Active);
+                assert_eq!(target, crate::state::SpecPhase::Refining);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/barnstormer-core/src/command.rs
+++ b/crates/barnstormer-core/src/command.rs
@@ -175,7 +175,7 @@ mod tests {
         };
         let json = serde_json::to_string(&cmd).unwrap();
         assert!(json.contains("\"TransitionPhase\""));
-        assert!(json.contains("\"refining\""));
+        assert!(json.contains("\"Refining\""));
         let back: Command = serde_json::from_str(&json).unwrap();
         match back {
             Command::TransitionPhase { target } => {

--- a/crates/barnstormer-core/src/command.rs
+++ b/crates/barnstormer-core/src/command.rs
@@ -77,6 +77,14 @@ pub enum Command {
         content: String,
     },
     Undo,
+    StreamDelta {
+        agent_id: String,
+        text: String,
+    },
+    StreamToolActivity {
+        agent_id: String,
+        activity: String,
+    },
 }
 
 #[cfg(test)]

--- a/crates/barnstormer-core/src/event.rs
+++ b/crates/barnstormer-core/src/event.rs
@@ -86,6 +86,26 @@ pub enum EventPayload {
     CanvasUpdated {
         content: String,
     },
+    StreamingDelta {
+        agent_id: String,
+        text: String,
+    },
+    StreamingToolActivity {
+        agent_id: String,
+        activity: String,
+    },
+}
+
+impl EventPayload {
+    /// Returns true for events that should not be persisted to the event log.
+    /// Streaming events are broadcast-only — they carry ephemeral LLM state
+    /// that has no meaning during replay.
+    pub fn is_ephemeral(&self) -> bool {
+        matches!(
+            self,
+            EventPayload::StreamingDelta { .. } | EventPayload::StreamingToolActivity { .. }
+        )
+    }
 }
 
 #[cfg(test)]
@@ -232,5 +252,49 @@ mod tests {
         round_trip_event(EventPayload::CanvasUpdated {
             content: "<h1>Test</h1>".to_string(),
         });
+    }
+
+    #[test]
+    fn streaming_delta_round_trip() {
+        round_trip_event(EventPayload::StreamingDelta {
+            agent_id: "manager-1".to_string(),
+            text: "Hello".to_string(),
+        });
+    }
+
+    #[test]
+    fn streaming_tool_activity_round_trip() {
+        round_trip_event(EventPayload::StreamingToolActivity {
+            agent_id: "brainstormer-1".to_string(),
+            activity: "creating card 'Auth Flow'".to_string(),
+        });
+    }
+
+    #[test]
+    fn is_ephemeral_returns_true_for_streaming_events() {
+        assert!(EventPayload::StreamingDelta {
+            agent_id: String::new(),
+            text: String::new(),
+        }
+        .is_ephemeral());
+        assert!(EventPayload::StreamingToolActivity {
+            agent_id: String::new(),
+            activity: String::new(),
+        }
+        .is_ephemeral());
+    }
+
+    #[test]
+    fn is_ephemeral_returns_false_for_durable_events() {
+        assert!(!EventPayload::SpecCreated {
+            title: String::new(),
+            one_liner: String::new(),
+            goal: String::new(),
+        }
+        .is_ephemeral());
+        assert!(!EventPayload::TranscriptAppended {
+            message: TranscriptMessage::new("x".into(), "y".into()),
+        }
+        .is_ephemeral());
     }
 }

--- a/crates/barnstormer-core/src/export/dot.rs
+++ b/crates/barnstormer-core/src/export/dot.rs
@@ -480,7 +480,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         }
     }
@@ -971,7 +971,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         };
         let dot = export_dot(&state);
@@ -992,7 +992,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         };
         let dot = export_dot(&state);
@@ -1032,7 +1032,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         };
         let dot = export_dot(&state);

--- a/crates/barnstormer-core/src/export/markdown.rs
+++ b/crates/barnstormer-core/src/export/markdown.rs
@@ -185,7 +185,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         }
     }

--- a/crates/barnstormer-core/src/export/spec.rs
+++ b/crates/barnstormer-core/src/export/spec.rs
@@ -144,7 +144,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         }
     }

--- a/crates/barnstormer-core/src/export/yaml.rs
+++ b/crates/barnstormer-core/src/export/yaml.rs
@@ -186,7 +186,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         }
     }

--- a/crates/barnstormer-core/src/state.rs
+++ b/crates/barnstormer-core/src/state.rs
@@ -20,10 +20,9 @@ pub struct UndoEntry {
 
 /// Tracks which lifecycle phase a spec is in.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub enum SpecPhase {
     Brainstorming,
-    #[serde(alias = "active")]
+    #[serde(alias = "Active")]
     Refining,
     Complete,
 }
@@ -789,7 +788,7 @@ mod tests {
     fn spec_phase_serde_brainstorming() {
         let phase = SpecPhase::Brainstorming;
         let json = serde_json::to_string(&phase).unwrap();
-        assert_eq!(json, "\"brainstorming\"");
+        assert_eq!(json, "\"Brainstorming\"");
         let back: SpecPhase = serde_json::from_str(&json).unwrap();
         assert_eq!(back, SpecPhase::Brainstorming);
     }
@@ -798,15 +797,15 @@ mod tests {
     fn spec_phase_serde_refining() {
         let phase = SpecPhase::Refining;
         let json = serde_json::to_string(&phase).unwrap();
-        assert_eq!(json, "\"refining\"");
+        assert_eq!(json, "\"Refining\"");
         let back: SpecPhase = serde_json::from_str(&json).unwrap();
         assert_eq!(back, SpecPhase::Refining);
     }
 
     #[test]
     fn spec_phase_serde_active_alias_deserializes_as_refining() {
-        // Backwards compat: persisted events with "active" should deserialize as Refining
-        let back: SpecPhase = serde_json::from_str("\"active\"").unwrap();
+        // Backwards compat: persisted events with "Active" should deserialize as Refining
+        let back: SpecPhase = serde_json::from_str("\"Active\"").unwrap();
         assert_eq!(back, SpecPhase::Refining);
     }
 
@@ -931,7 +930,7 @@ mod tests {
     fn spec_phase_serde_complete() {
         let phase = SpecPhase::Complete;
         let json = serde_json::to_string(&phase).unwrap();
-        assert_eq!(json, "\"complete\"");
+        assert_eq!(json, "\"Complete\"");
         let back: SpecPhase = serde_json::from_str(&json).unwrap();
         assert_eq!(back, SpecPhase::Complete);
     }

--- a/crates/barnstormer-core/src/state.rs
+++ b/crates/barnstormer-core/src/state.rs
@@ -23,11 +23,12 @@ pub struct UndoEntry {
 #[serde(rename_all = "snake_case")]
 pub enum SpecPhase {
     Brainstorming,
-    Active,
+    #[serde(alias = "active")]
+    Refining,
 }
 
-fn default_phase_active() -> SpecPhase {
-    SpecPhase::Active
+fn default_phase_refining() -> SpecPhase {
+    SpecPhase::Refining
 }
 
 /// The full materialized state of a spec, built by replaying events.
@@ -40,7 +41,7 @@ pub struct SpecState {
     pub undo_stack: Vec<UndoEntry>,
     pub last_event_id: u64,
     pub lanes: Vec<String>,
-    #[serde(default = "default_phase_active")]
+    #[serde(default = "default_phase_refining")]
     pub phase: SpecPhase,
     #[serde(default)]
     pub canvas_content: Option<String>,
@@ -56,7 +57,7 @@ impl Default for SpecState {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         }
     }
@@ -793,24 +794,31 @@ mod tests {
     }
 
     #[test]
-    fn spec_phase_serde_active() {
-        let phase = SpecPhase::Active;
+    fn spec_phase_serde_refining() {
+        let phase = SpecPhase::Refining;
         let json = serde_json::to_string(&phase).unwrap();
-        assert_eq!(json, "\"active\"");
+        assert_eq!(json, "\"refining\"");
         let back: SpecPhase = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, SpecPhase::Active);
+        assert_eq!(back, SpecPhase::Refining);
     }
 
     #[test]
-    fn spec_state_new_defaults_to_active() {
+    fn spec_phase_serde_active_alias_deserializes_as_refining() {
+        // Backwards compat: persisted events with "active" should deserialize as Refining
+        let back: SpecPhase = serde_json::from_str("\"active\"").unwrap();
+        assert_eq!(back, SpecPhase::Refining);
+    }
+
+    #[test]
+    fn spec_state_new_defaults_to_refining() {
         let state = SpecState::new();
-        assert_eq!(state.phase, SpecPhase::Active);
+        assert_eq!(state.phase, SpecPhase::Refining);
     }
 
     #[test]
     fn phase_transitioned_updates_state() {
         let mut state = SpecState::new();
-        assert_eq!(state.phase, SpecPhase::Active);
+        assert_eq!(state.phase, SpecPhase::Refining);
 
         let event = Event {
             event_id: 1,
@@ -919,10 +927,10 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_without_phase_deserializes_as_active() {
+    fn snapshot_without_phase_deserializes_as_refining() {
         // Simulate an old snapshot JSON without a "phase" field
         let json = r#"{"core":null,"cards":{},"transcript":[],"pending_question":null,"undo_stack":[],"last_event_id":0,"lanes":["Ideas","Plan","Spec"]}"#;
         let state: SpecState = serde_json::from_str(json).unwrap();
-        assert_eq!(state.phase, SpecPhase::Active);
+        assert_eq!(state.phase, SpecPhase::Refining);
     }
 }

--- a/crates/barnstormer-core/src/state.rs
+++ b/crates/barnstormer-core/src/state.rs
@@ -297,6 +297,14 @@ impl SpecState {
                 self.phase = phase.clone();
                 // No undo entry — phase transitions are lifecycle events
             }
+
+            EventPayload::StreamingDelta { .. } => {
+                // Ephemeral — no state mutation
+            }
+
+            EventPayload::StreamingToolActivity { .. } => {
+                // Ephemeral — no state mutation
+            }
         }
     }
 
@@ -353,6 +361,12 @@ impl SpecState {
                 } else {
                     self.canvas_content = Some(content.clone());
                 }
+            }
+            EventPayload::StreamingDelta { .. } => {
+                // Ephemeral — no state mutation
+            }
+            EventPayload::StreamingToolActivity { .. } => {
+                // Ephemeral — no state mutation
             }
             // Other event types during undo are applied normally
             _ => {
@@ -924,6 +938,25 @@ mod tests {
         let json = serde_json::to_string(&SpecState::new()).unwrap();
         let back: SpecState = serde_json::from_str(&json).unwrap();
         assert_eq!(back.canvas_content, None);
+    }
+
+    #[test]
+    fn apply_streaming_delta_is_noop() {
+        let mut state = SpecState::new();
+        let spec_id = make_spec_id();
+        let before_cards = state.cards.len();
+        let before_transcript = state.transcript.len();
+        state.apply(&make_event(
+            1,
+            spec_id,
+            EventPayload::StreamingDelta {
+                agent_id: "manager-1".to_string(),
+                text: "Hello".to_string(),
+            },
+        ));
+        assert_eq!(state.cards.len(), before_cards);
+        assert_eq!(state.transcript.len(), before_transcript);
+        assert!(state.core.is_none());
     }
 
     #[test]

--- a/crates/barnstormer-core/src/state.rs
+++ b/crates/barnstormer-core/src/state.rs
@@ -25,6 +25,7 @@ pub enum SpecPhase {
     Brainstorming,
     #[serde(alias = "active")]
     Refining,
+    Complete,
 }
 
 fn default_phase_refining() -> SpecPhase {
@@ -924,6 +925,15 @@ mod tests {
         let json = serde_json::to_string(&SpecState::new()).unwrap();
         let back: SpecState = serde_json::from_str(&json).unwrap();
         assert_eq!(back.canvas_content, None);
+    }
+
+    #[test]
+    fn spec_phase_serde_complete() {
+        let phase = SpecPhase::Complete;
+        let json = serde_json::to_string(&phase).unwrap();
+        assert_eq!(json, "\"complete\"");
+        let back: SpecPhase = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, SpecPhase::Complete);
     }
 
     #[test]

--- a/crates/barnstormer-server/src/api/stream.rs
+++ b/crates/barnstormer-server/src/api/stream.rs
@@ -30,6 +30,8 @@ fn event_type_name(payload: &barnstormer_core::EventPayload) -> &'static str {
         barnstormer_core::EventPayload::SnapshotWritten { .. } => "snapshot_written",
         barnstormer_core::EventPayload::PhaseTransitioned { .. } => "phase_transitioned",
         barnstormer_core::EventPayload::CanvasUpdated { .. } => "canvas_updated",
+        barnstormer_core::EventPayload::StreamingDelta { .. } => "streaming_delta",
+        barnstormer_core::EventPayload::StreamingToolActivity { .. } => "streaming_tool_activity",
     }
 }
 

--- a/crates/barnstormer-server/src/api/stream.rs
+++ b/crates/barnstormer-server/src/api/stream.rs
@@ -159,6 +159,26 @@ mod tests {
     }
 
     #[test]
+    fn event_type_names_streaming() {
+        use barnstormer_core::EventPayload;
+
+        assert_eq!(
+            event_type_name(&EventPayload::StreamingDelta {
+                agent_id: String::new(),
+                text: String::new(),
+            }),
+            "streaming_delta"
+        );
+        assert_eq!(
+            event_type_name(&EventPayload::StreamingToolActivity {
+                agent_id: String::new(),
+                activity: String::new(),
+            }),
+            "streaming_tool_activity"
+        );
+    }
+
+    #[test]
     fn event_type_names_are_correct() {
         use barnstormer_core::Card;
         use barnstormer_core::EventPayload;

--- a/crates/barnstormer-server/src/config.rs
+++ b/crates/barnstormer-server/src/config.rs
@@ -18,6 +18,20 @@ pub enum ConfigError {
     RemoteWithoutToken,
 }
 
+/// Expand a leading `~` in a path string to the user's home directory.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    } else if path == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    PathBuf::from(path)
+}
+
 /// Server configuration loaded from environment variables.
 #[derive(Debug, Clone)]
 pub struct BarnstormerConfig {
@@ -43,7 +57,7 @@ impl BarnstormerConfig {
     /// - BARNSTORMER_PUBLIC_BASE_URL: public URL for the server (default: http://localhost:7331)
     pub fn from_env() -> Result<Self, ConfigError> {
         let home = std::env::var("BARNSTORMER_HOME")
-            .map(PathBuf::from)
+            .map(|v| expand_tilde(&v))
             .unwrap_or_else(|_| {
                 std::env::var("HOME")
                     .map(PathBuf::from)
@@ -132,6 +146,15 @@ mod tests {
         assert_eq!(config.default_provider, "anthropic");
         assert!(config.default_model.is_none());
         assert!(config.home.to_string_lossy().contains(".barnstormer"));
+    }
+
+    #[test]
+    fn expand_tilde_expands_home() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(expand_tilde("~/.barnstormer"), PathBuf::from(&home).join(".barnstormer"));
+        assert_eq!(expand_tilde("~"), PathBuf::from(&home));
+        assert_eq!(expand_tilde("/absolute/path"), PathBuf::from("/absolute/path"));
+        assert_eq!(expand_tilde("relative/path"), PathBuf::from("relative/path"));
     }
 
     #[test]

--- a/crates/barnstormer-server/src/routes.rs
+++ b/crates/barnstormer-server/src/routes.rs
@@ -57,6 +57,7 @@ pub fn create_router(state: SharedState, auth_token: Option<String>) -> Router {
         .route("/web/specs/{id}/export/dot", get(web::export_dot))
         .route("/web/specs/{id}/export/spec", get(web::export_spec_download))
         .route("/web/specs/{id}/phase", post(web::transition_phase))
+        .route("/web/specs/{id}/phase-check", get(web::phase_check))
         .route("/web/specs/{id}/undo", post(web::undo))
         .route("/web/specs/{id}/regenerate", post(web::regenerate))
         .route("/web/provider-status", get(web::provider_status))

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -249,7 +249,7 @@ pub async fn import_spec(
     let spec_id_str = spec_id.to_string();
     let phase = match spec_state.phase {
         SpecPhase::Brainstorming => "brainstorming".to_string(),
-        SpecPhase::Active => "active".to_string(),
+        SpecPhase::Refining => "refining".to_string(),
     };
 
     let has_pending_question = spec_state.pending_question.is_some();
@@ -430,7 +430,7 @@ pub async fn create_spec(
     let spec_id_str = spec_id.to_string();
     let phase = match spec_state.phase {
         SpecPhase::Brainstorming => "brainstorming".to_string(),
-        SpecPhase::Active => "active".to_string(),
+        SpecPhase::Refining => "refining".to_string(),
     };
 
     let has_pending_question = spec_state.pending_question.is_some();
@@ -631,7 +631,7 @@ pub async fn spec_view(
     let lanes = cards_by_lane(&spec_state);
     let phase = match spec_state.phase {
         SpecPhase::Brainstorming => "brainstorming".to_string(),
-        SpecPhase::Active => "active".to_string(),
+        SpecPhase::Refining => "refining".to_string(),
     };
 
     let has_pending_question = spec_state.pending_question.is_some();
@@ -2129,7 +2129,7 @@ pub async fn transition_phase(
 
     let target = match form.target.as_str() {
         "brainstorming" => SpecPhase::Brainstorming,
-        "active" => SpecPhase::Active,
+        "refining" => SpecPhase::Refining,
         _ => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -2157,7 +2157,7 @@ pub async fn transition_phase(
         Ok(_) => {
             let label = match target {
                 SpecPhase::Brainstorming => "Brainstorming",
-                SpecPhase::Active => "Active",
+                SpecPhase::Refining => "Refining",
             };
             (
                 StatusCode::OK,
@@ -3145,7 +3145,7 @@ mod tests {
             title: "Test Spec".to_string(),
             one_liner: "A test spec".to_string(),
             goal: "Test goal".to_string(),
-            phase: "active".to_string(),
+            phase: "refining".to_string(),
             lanes: vec![],
             canvas_content: None,
             has_pending_question: false,
@@ -3834,7 +3834,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_panel_active_no_fullwidth_class() {
+    async fn chat_panel_refining_no_fullwidth_class() {
         let state = test_state();
         let app = create_router(Arc::clone(&state), None);
         app.oneshot(
@@ -3851,12 +3851,12 @@ mod tests {
             *actors.keys().next().unwrap()
         };
 
-        // Transition to Active
+        // Transition to Refining
         let actors = state.actors.read().await;
         let handle = actors.get(&spec_id).unwrap();
         handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();
@@ -4649,7 +4649,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn phase_transition_to_active_returns_200() {
+    async fn phase_transition_to_refining_returns_200() {
         let state = test_state();
         let app = create_router(Arc::clone(&state), None);
         app.oneshot(
@@ -4671,7 +4671,7 @@ mod tests {
             .oneshot(
                 Request::post(&format!("/web/specs/{}/phase", spec_id))
                     .header("content-type", "application/x-www-form-urlencoded")
-                    .body(Body::from("target=active"))
+                    .body(Body::from("target=refining"))
                     .unwrap(),
             )
             .await
@@ -4697,12 +4697,12 @@ mod tests {
             *actors.keys().next().unwrap()
         };
 
-        // First transition to Active
+        // First transition to Refining
         let app2 = create_router(Arc::clone(&state), None);
         app2.oneshot(
             Request::post(&format!("/web/specs/{}/phase", spec_id))
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body(Body::from("target=active"))
+                .body(Body::from("target=refining"))
                 .unwrap(),
         )
         .await
@@ -4771,24 +4771,24 @@ mod tests {
             *actors.keys().next().unwrap()
         };
 
-        // Transition to active first
+        // Transition to refining first
         let app2 = create_router(Arc::clone(&state), None);
         app2.oneshot(
             Request::post(&format!("/web/specs/{}/phase", spec_id))
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body(Body::from("target=active"))
+                .body(Body::from("target=refining"))
                 .unwrap(),
         )
         .await
         .unwrap();
 
-        // Try active again — 409
+        // Try refining again — 409
         let app3 = create_router(Arc::clone(&state), None);
         let resp = app3
             .oneshot(
                 Request::post(&format!("/web/specs/{}/phase", spec_id))
                     .header("content-type", "application/x-www-form-urlencoded")
-                    .body(Body::from("target=active"))
+                    .body(Body::from("target=refining"))
                     .unwrap(),
             )
             .await
@@ -4805,7 +4805,7 @@ mod tests {
             .oneshot(
                 Request::post(&format!("/web/specs/{}/phase", fake_id))
                     .header("content-type", "application/x-www-form-urlencoded")
-                    .body(Body::from("target=active"))
+                    .body(Body::from("target=refining"))
                     .unwrap(),
             )
             .await
@@ -4901,7 +4901,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spec_view_active_contains_tab_toggles() {
+    async fn spec_view_refining_contains_tab_toggles() {
         let state = test_state();
         let app = create_router(Arc::clone(&state), None);
         app.oneshot(
@@ -4918,12 +4918,12 @@ mod tests {
             *actors.keys().next().unwrap()
         };
 
-        // Transition to Active
+        // Transition to Refining
         let actors = state.actors.read().await;
         let handle = actors.get(&spec_id).unwrap();
         handle
             .send_command(Command::TransitionPhase {
-                target: SpecPhase::Active,
+                target: SpecPhase::Refining,
             })
             .await
             .unwrap();

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -250,6 +250,7 @@ pub async fn import_spec(
     let phase = match spec_state.phase {
         SpecPhase::Brainstorming => "brainstorming".to_string(),
         SpecPhase::Refining => "refining".to_string(),
+        SpecPhase::Complete => "complete".to_string(),
     };
 
     let has_pending_question = spec_state.pending_question.is_some();
@@ -431,6 +432,7 @@ pub async fn create_spec(
     let phase = match spec_state.phase {
         SpecPhase::Brainstorming => "brainstorming".to_string(),
         SpecPhase::Refining => "refining".to_string(),
+        SpecPhase::Complete => "complete".to_string(),
     };
 
     let has_pending_question = spec_state.pending_question.is_some();
@@ -632,6 +634,7 @@ pub async fn spec_view(
     let phase = match spec_state.phase {
         SpecPhase::Brainstorming => "brainstorming".to_string(),
         SpecPhase::Refining => "refining".to_string(),
+        SpecPhase::Complete => "complete".to_string(),
     };
 
     let has_pending_question = spec_state.pending_question.is_some();
@@ -2130,6 +2133,7 @@ pub async fn transition_phase(
     let target = match form.target.as_str() {
         "brainstorming" => SpecPhase::Brainstorming,
         "refining" => SpecPhase::Refining,
+        "complete" => SpecPhase::Complete,
         _ => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -2158,6 +2162,7 @@ pub async fn transition_phase(
             let label = match target {
                 SpecPhase::Brainstorming => "Brainstorming",
                 SpecPhase::Refining => "Refining",
+                SpecPhase::Complete => "Complete",
             };
             (
                 StatusCode::OK,

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -1388,7 +1388,6 @@ pub struct ChatTranscriptTemplate {
 pub struct ChatPanelTemplate {
     pub spec_id: String,
     pub container_id: String,
-    pub is_fullwidth: bool,
     pub transcript: Vec<TranscriptEntry>,
     pub pending_question: Option<QuestionData>,
 }
@@ -1417,8 +1416,7 @@ pub async fn chat_panel(
 
     let spec_state = handle.read_state().await;
 
-    let is_fullwidth = spec_state.phase == SpecPhase::Brainstorming;
-    let container_id = if is_fullwidth {
+    let container_id = if spec_state.phase == SpecPhase::Brainstorming {
         "brainstorm-chat".to_string()
     } else {
         "chat-transcript".to_string()
@@ -1437,7 +1435,6 @@ pub async fn chat_panel(
     ChatPanelTemplate {
         spec_id: id,
         container_id,
-        is_fullwidth,
         transcript,
         pending_question,
     }
@@ -3642,7 +3639,7 @@ mod tests {
         let tmpl = ChatPanelTemplate {
             spec_id: "01HTEST".to_string(),
             container_id: "chat-transcript".to_string(),
-            is_fullwidth: false,
+
             transcript: vec![],
             pending_question: None,
         };
@@ -3655,7 +3652,7 @@ mod tests {
         let tmpl = ChatPanelTemplate {
             spec_id: "01HTEST".to_string(),
             container_id: "chat-transcript".to_string(),
-            is_fullwidth: false,
+
             transcript: vec![
                 TranscriptEntry {
                     sender: "human".to_string(),
@@ -3698,7 +3695,7 @@ mod tests {
         let tmpl = ChatPanelTemplate {
             spec_id: "01HTEST".to_string(),
             container_id: "chat-transcript".to_string(),
-            is_fullwidth: false,
+
             transcript: vec![],
             pending_question: None,
         };
@@ -3713,7 +3710,7 @@ mod tests {
         let tmpl = ChatPanelTemplate {
             spec_id: "01HTEST".to_string(),
             container_id: "chat-transcript".to_string(),
-            is_fullwidth: false,
+
             transcript: vec![],
             pending_question: None,
         };
@@ -3730,7 +3727,7 @@ mod tests {
         let tmpl = ChatPanelTemplate {
             spec_id: "01HTEST".to_string(),
             container_id: "chat-transcript".to_string(),
-            is_fullwidth: false,
+
             transcript: vec![],
             pending_question: None,
         };
@@ -3801,13 +3798,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_panel_brainstorming_has_fullwidth_class() {
+    async fn chat_panel_brainstorming_targets_brainstorm_chat() {
         let state = test_state();
         let app = create_router(Arc::clone(&state), None);
         app.oneshot(
             Request::post("/web/specs")
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body(Body::from("description=Chat+fullwidth+test"))
+                .body(Body::from("description=Chat+brainstorm+test"))
                 .unwrap(),
         )
         .await
@@ -3833,19 +3830,23 @@ mod tests {
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(
-            html.contains("chat-fullwidth"),
-            "should have fullwidth class in brainstorming"
+            html.contains("brainstorm-chat"),
+            "should target brainstorm-chat container in brainstorming"
+        );
+        assert!(
+            !html.contains("chat-fullwidth"),
+            "should not have chat-fullwidth class (removed)"
         );
     }
 
     #[tokio::test]
-    async fn chat_panel_refining_no_fullwidth_class() {
+    async fn chat_panel_refining_targets_chat_transcript() {
         let state = test_state();
         let app = create_router(Arc::clone(&state), None);
         app.oneshot(
             Request::post("/web/specs")
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body(Body::from("description=Chat+active+test"))
+                .body(Body::from("description=Chat+refining+test"))
                 .unwrap(),
         )
         .await
@@ -3881,8 +3882,12 @@ mod tests {
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(
+            html.contains("chat-transcript"),
+            "should target chat-transcript container in refining"
+        );
+        assert!(
             !html.contains("chat-fullwidth"),
-            "should not have fullwidth class in active"
+            "should not have chat-fullwidth class (removed)"
         );
     }
 

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use axum::extract::{Form, Path, Query, State};
-use axum::http::{header, StatusCode};
+use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
 use serde::Deserialize;
 use barnstormer_agent::SwarmOrchestrator;
@@ -1037,6 +1037,7 @@ pub async fn delete_card(
 pub struct DocumentTemplate {
     pub spec_id: String,
     pub title: String,
+    pub title_slug: String,
     pub one_liner: String,
     pub goal: String,
     pub goal_html: String,
@@ -1091,6 +1092,7 @@ pub async fn document(
 
     DocumentTemplate {
         spec_id: id,
+        title_slug: slugify(&core.title),
         title: core.title.clone(),
         one_liner: core.one_liner.clone(),
         goal: core.goal.clone(),
@@ -1130,6 +1132,36 @@ pub struct TranscriptEntry {
 /// Render markdown content to HTML, stripping raw HTML tags from input
 /// to prevent XSS. Handles paragraphs, bold, italic, lists, code blocks,
 /// and links.
+/// Convert a spec title into a URL/filename-safe slug.
+fn slugify(title: &str) -> String {
+    let slug: String = title
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    // Collapse multiple dashes and trim leading/trailing dashes
+    let mut result = String::new();
+    let mut prev_dash = false;
+    for c in slug.chars() {
+        if c == '-' {
+            if !prev_dash && !result.is_empty() {
+                result.push('-');
+            }
+            prev_dash = true;
+        } else {
+            result.push(c);
+            prev_dash = false;
+        }
+    }
+    result.trim_end_matches('-').to_string()
+}
+
 fn render_markdown(content: &str) -> String {
     let options = Options::empty();
     let parser = Parser::new_ext(content, options).filter(|event| {
@@ -1564,6 +1596,7 @@ pub async fn chat_panel(
 #[template(path = "partials/artifacts.html")]
 pub struct ArtifactsTemplate {
     pub spec_id: String,
+    pub title_slug: String,
     pub markdown_content: String,
     pub yaml_content: String,
     pub dot_content: String,
@@ -1599,8 +1632,15 @@ pub async fn artifacts(
     });
     let dot_content = barnstormer_core::export::export_dot(&spec_state);
 
+    let title_slug = spec_state
+        .core
+        .as_ref()
+        .map(|c| slugify(&c.title))
+        .unwrap_or_else(|| "spec".to_string());
+
     ArtifactsTemplate {
         spec_id: id,
+        title_slug,
         markdown_content,
         yaml_content,
         dot_content,
@@ -1613,6 +1653,7 @@ pub async fn artifacts(
 #[template(path = "partials/spec.html")]
 pub struct SpecTabTemplate {
     pub spec_id: String,
+    pub title_slug: String,
     pub spec_html: String,
     pub spec_markdown: String,
 }
@@ -1640,11 +1681,17 @@ pub async fn spec(
     };
 
     let spec_state = handle.read_state().await;
+    let title_slug = spec_state
+        .core
+        .as_ref()
+        .map(|c| slugify(&c.title))
+        .unwrap_or_else(|| "spec".to_string());
     let spec_markdown = barnstormer_core::export::export_spec(&spec_state);
     let spec_html = render_markdown(&spec_markdown);
 
     SpecTabTemplate {
         spec_id: id,
+        title_slug,
         spec_html,
         spec_markdown,
     }
@@ -1674,11 +1721,19 @@ pub async fn export_markdown(
     };
 
     let spec_state = handle.read_state().await;
+    let slug = spec_state
+        .core
+        .as_ref()
+        .map(|c| slugify(&c.title))
+        .unwrap_or_else(|| "spec".to_string());
     let content = barnstormer_core::export::export_markdown(&spec_state);
 
     Response::builder()
-        .header("content-type", "text/markdown")
-        .header("content-disposition", "attachment; filename=\"spec.md\"")
+        .header("content-type", "text/markdown; charset=utf-8")
+        .header(
+            "content-disposition",
+            format!("attachment; filename=\"{}-spec.md\"", slug),
+        )
         .body(axum::body::Body::from(content))
         .unwrap()
         .into_response()
@@ -1707,12 +1762,17 @@ pub async fn export_yaml(
     };
 
     let spec_state = handle.read_state().await;
+    let slug = spec_state
+        .core
+        .as_ref()
+        .map(|c| slugify(&c.title))
+        .unwrap_or_else(|| "spec".to_string());
     match barnstormer_core::export::export_yaml(&spec_state) {
         Ok(content) => Response::builder()
-            .header("content-type", "text/yaml")
+            .header("content-type", "text/yaml; charset=utf-8")
             .header(
                 "content-disposition",
-                "attachment; filename=\"spec.yaml\"",
+                format!("attachment; filename=\"{}-spec.yaml\"", slug),
             )
             .body(axum::body::Body::from(content))
             .unwrap()
@@ -1751,11 +1811,19 @@ pub async fn export_dot(
     };
 
     let spec_state = handle.read_state().await;
+    let slug = spec_state
+        .core
+        .as_ref()
+        .map(|c| slugify(&c.title))
+        .unwrap_or_else(|| "spec".to_string());
     let content = barnstormer_core::export::export_dot(&spec_state);
 
     Response::builder()
-        .header("content-type", "text/plain")
-        .header("content-disposition", "attachment; filename=\"spec.dot\"")
+        .header("content-type", "text/plain; charset=utf-8")
+        .header(
+            "content-disposition",
+            format!("attachment; filename=\"{}-spec.dot\"", slug),
+        )
         .body(axum::body::Body::from(content))
         .unwrap()
         .into_response()
@@ -1784,19 +1852,22 @@ pub async fn export_spec_download(
     };
 
     let spec_state = handle.read_state().await;
+    let slug = spec_state
+        .core
+        .as_ref()
+        .map(|c| slugify(&c.title))
+        .unwrap_or_else(|| "spec".to_string());
     let content = barnstormer_core::export::export_spec(&spec_state);
+    let filename = format!("{}-spec.md", slug);
 
-    (
-        StatusCode::OK,
-        [
-            (header::CONTENT_TYPE, "text/markdown; charset=utf-8"),
-            (
-                header::CONTENT_DISPOSITION,
-                "attachment; filename=\"spec.md\"",
-            ),
-        ],
-        content,
-    )
+    Response::builder()
+        .header("content-type", "text/markdown; charset=utf-8")
+        .header(
+            "content-disposition",
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .body(axum::body::Body::from(content))
+        .unwrap()
         .into_response()
 }
 
@@ -1841,22 +1912,11 @@ pub async fn regenerate(
     if let Err(e) = std::fs::create_dir_all(&exports_dir) {
         tracing::error!("failed to create exports directory: {}", e);
     } else {
-        let spec_title = spec_state
+        let slug = spec_state
             .core
             .as_ref()
-            .map(|c| c.title.clone())
+            .map(|c| slugify(&c.title))
             .unwrap_or_else(|| "spec".to_string());
-        let slug: String = spec_title
-            .to_lowercase()
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                    c
-                } else {
-                    '-'
-                }
-            })
-            .collect();
 
         if let Err(e) = std::fs::write(exports_dir.join(format!("{}.md", slug)), &markdown_content) {
             tracing::error!("failed to write markdown export: {}", e);
@@ -3028,6 +3088,7 @@ mod tests {
         let tmpl = DocumentTemplate {
             spec_id: "01HTEST".to_string(),
             title: "Test Doc".to_string(),
+            title_slug: "test-doc".to_string(),
             one_liner: "A test document".to_string(),
             goal: "Verify rendering".to_string(),
             goal_html: "<p>Verify rendering</p>\n".to_string(),
@@ -4067,6 +4128,7 @@ mod tests {
     fn artifacts_template_renders() {
         let tmpl = ArtifactsTemplate {
             spec_id: "01HTEST".to_string(),
+            title_slug: "my-spec".to_string(),
             markdown_content: "# My Spec".to_string(),
             yaml_content: "title: My Spec".to_string(),
             dot_content: "digraph {}".to_string(),
@@ -4079,6 +4141,7 @@ mod tests {
     fn artifacts_template_contains_all_content_sections() {
         let tmpl = ArtifactsTemplate {
             spec_id: "01HTEST".to_string(),
+            title_slug: "my-spec".to_string(),
             markdown_content: "# My Spec".to_string(),
             yaml_content: "title: My Spec".to_string(),
             dot_content: "digraph {}".to_string(),
@@ -4096,6 +4159,7 @@ mod tests {
     fn artifacts_template_contains_download_links() {
         let tmpl = ArtifactsTemplate {
             spec_id: "01HTEST".to_string(),
+            title_slug: "test".to_string(),
             markdown_content: "# Test".to_string(),
             yaml_content: "title: Test".to_string(),
             dot_content: "digraph {}".to_string(),
@@ -4113,15 +4177,16 @@ mod tests {
             rendered.contains("/web/specs/01HTEST/export/dot"),
             "should contain dot download link"
         );
-        assert!(rendered.contains("download=\"spec.md\""), "should have spec.md download attribute");
-        assert!(rendered.contains("download=\"spec.yaml\""), "should have spec.yaml download attribute");
-        assert!(rendered.contains("download=\"spec.dot\""), "should have spec.dot download attribute");
+        assert!(rendered.contains("download=\"test-spec.md\""), "should have slugged .md download attribute");
+        assert!(rendered.contains("download=\"test-spec.yaml\""), "should have slugged .yaml download attribute");
+        assert!(rendered.contains("download=\"test-spec.dot\""), "should have slugged .dot download attribute");
     }
 
     #[test]
     fn artifacts_template_contains_copy_buttons() {
         let tmpl = ArtifactsTemplate {
             spec_id: "01HTEST".to_string(),
+            title_slug: "test".to_string(),
             markdown_content: "# Test".to_string(),
             yaml_content: "title: Test".to_string(),
             dot_content: "digraph {}".to_string(),
@@ -4242,6 +4307,7 @@ mod tests {
     fn spec_template_renders_with_content() {
         let tmpl = SpecTabTemplate {
             spec_id: "01HTEST".to_string(),
+            title_slug: "test".to_string(),
             spec_html: "<h1>Test</h1>".to_string(),
             spec_markdown: "# Test".to_string(),
         };
@@ -4254,6 +4320,7 @@ mod tests {
     fn spec_template_renders_empty_state() {
         let tmpl = SpecTabTemplate {
             spec_id: "01HTEST".to_string(),
+            title_slug: "test".to_string(),
             spec_html: String::new(),
             spec_markdown: String::new(),
         };
@@ -4298,11 +4365,13 @@ mod tests {
         assert_eq!(resp.status(), 200);
         assert_eq!(
             resp.headers().get("content-type").unwrap(),
-            "text/markdown"
+            "text/markdown; charset=utf-8"
         );
-        assert_eq!(
-            resp.headers().get("content-disposition").unwrap(),
-            "attachment; filename=\"spec.md\""
+        let disposition = resp.headers().get("content-disposition").unwrap().to_str().unwrap();
+        assert!(
+            disposition.contains("attachment") && disposition.contains("-spec.md"),
+            "should have slugged filename in content-disposition, got: {}",
+            disposition
         );
     }
 
@@ -4324,11 +4393,13 @@ mod tests {
         assert_eq!(resp.status(), 200);
         assert_eq!(
             resp.headers().get("content-type").unwrap(),
-            "text/yaml"
+            "text/yaml; charset=utf-8"
         );
-        assert_eq!(
-            resp.headers().get("content-disposition").unwrap(),
-            "attachment; filename=\"spec.yaml\""
+        let disposition = resp.headers().get("content-disposition").unwrap().to_str().unwrap();
+        assert!(
+            disposition.contains("attachment") && disposition.contains("-spec.yaml"),
+            "should have slugged filename in content-disposition, got: {}",
+            disposition
         );
     }
 
@@ -4350,11 +4421,13 @@ mod tests {
         assert_eq!(resp.status(), 200);
         assert_eq!(
             resp.headers().get("content-type").unwrap(),
-            "text/plain"
+            "text/plain; charset=utf-8"
         );
-        assert_eq!(
-            resp.headers().get("content-disposition").unwrap(),
-            "attachment; filename=\"spec.dot\""
+        let disposition = resp.headers().get("content-disposition").unwrap().to_str().unwrap();
+        assert!(
+            disposition.contains("attachment") && disposition.contains("-spec.dot"),
+            "should have slugged filename in content-disposition, got: {}",
+            disposition
         );
     }
 

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -2671,6 +2671,9 @@ pub fn spawn_event_persister(
         loop {
             match rx.recv().await {
                 Ok(event) => {
+                    if event.payload.is_ephemeral() {
+                        continue;
+                    }
                     if let Err(e) = log.append(&event) {
                         tracing::error!(
                             "event persister failed to write event for spec {}: {}",

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -1079,6 +1079,8 @@ pub struct TranscriptEntry {
     /// Pre-rendered markdown→HTML for template use with `|safe`.
     pub content_html: String,
     pub timestamp: String,
+    /// Number of consecutive identical step messages collapsed into this one.
+    pub repeat_count: u32,
 }
 
 /// Render markdown content to HTML, stripping raw HTML tags from input
@@ -1110,6 +1112,7 @@ fn to_transcript_entry(m: &barnstormer_core::TranscriptMessage) -> TranscriptEnt
         content: m.content.clone(),
         content_html,
         timestamp: m.timestamp.format("%H:%M:%S").to_string(),
+        repeat_count: 1,
     }
 }
 
@@ -1122,6 +1125,25 @@ fn mark_continuations(entries: &mut [TranscriptEntry]) {
         if entries[i].sender == entries[i - 1].sender && !entries[i].is_step && !entries[i - 1].is_step {
             entries[i].is_continuation = true;
         }
+    }
+}
+
+/// Collapse consecutive identical step messages into a single entry with
+/// a repeat_count, so the UI can show "(x3)" instead of three identical lines.
+fn collapse_repeated_steps(entries: &mut Vec<TranscriptEntry>) {
+    let mut i = 0;
+    while i < entries.len() {
+        if entries[i].is_step {
+            let mut j = i + 1;
+            while j < entries.len() && entries[j].is_step && entries[j].content == entries[i].content {
+                entries[i].repeat_count += 1;
+                j += 1;
+            }
+            if entries[i].repeat_count > 1 {
+                entries.drain((i + 1)..j);
+            }
+        }
+        i += 1;
     }
 }
 
@@ -1299,11 +1321,13 @@ pub async fn activity(
 
     let spec_state = handle.read_state().await;
 
-    let transcript: Vec<TranscriptEntry> = spec_state
+    let mut transcript: Vec<TranscriptEntry> = spec_state
         .transcript
         .iter()
         .map(to_transcript_entry)
         .collect();
+    mark_continuations(&mut transcript);
+    collapse_repeated_steps(&mut transcript);
 
     let pending_question = spec_state.pending_question.as_ref().map(question_to_view_data);
 
@@ -1360,6 +1384,7 @@ pub async fn activity_transcript(
         .map(to_transcript_entry)
         .collect();
     mark_continuations(&mut transcript);
+    collapse_repeated_steps(&mut transcript);
 
     if is_chat {
         ChatTranscriptTemplate {
@@ -1438,6 +1463,7 @@ pub async fn chat_panel(
         .map(to_transcript_entry)
         .collect();
     mark_continuations(&mut transcript);
+    collapse_repeated_steps(&mut transcript);
 
     let pending_question = spec_state.pending_question.as_ref().map(question_to_view_data);
 
@@ -1878,6 +1904,7 @@ pub async fn answer_question(
         .map(to_transcript_entry)
         .collect();
     mark_continuations(&mut transcript);
+    collapse_repeated_steps(&mut transcript);
 
     if is_ticker {
         // For mission ticker, show only last 10 entries
@@ -2033,6 +2060,7 @@ pub async fn chat(
         .map(to_transcript_entry)
         .collect();
     mark_continuations(&mut transcript);
+    collapse_repeated_steps(&mut transcript);
 
     let pending_question = spec_state.pending_question.as_ref().map(question_to_view_data);
 
@@ -2945,6 +2973,7 @@ mod tests {
                 content: "Started analysis".to_string(),
                 content_html: "<p>Started analysis</p>\n".to_string(),
                 timestamp: "12:34:56".to_string(),
+                repeat_count: 1,
             }],
             pending_question: None,
         };
@@ -3102,6 +3131,7 @@ mod tests {
                 content: "Started analysis".to_string(),
                 content_html: "<p>Started analysis</p>\n".to_string(),
                 timestamp: "12:34:56".to_string(),
+                repeat_count: 1,
             }],
             pending_question: None,
         };
@@ -3127,6 +3157,7 @@ mod tests {
                 content: "Hello chat".to_string(),
                 content_html: "<p>Hello chat</p>\n".to_string(),
                 timestamp: "12:00:00".to_string(),
+                repeat_count: 1,
             }],
             pending_question: None,
         };
@@ -3232,6 +3263,7 @@ mod tests {
                 content: "Analyzing requirements".to_string(),
                 content_html: "<p>Analyzing requirements</p>\n".to_string(),
                 timestamp: "12:34:56".to_string(),
+                repeat_count: 1,
             }],
             pending_question: None,
         };
@@ -3691,6 +3723,7 @@ mod tests {
                     content: "Hello from human".to_string(),
                     content_html: "<p>Hello from human</p>\n".to_string(),
                     timestamp: "12:34:56".to_string(),
+                    repeat_count: 1,
                 },
                 TranscriptEntry {
                     sender: "manager-01HAGENT".to_string(),
@@ -3703,6 +3736,7 @@ mod tests {
                     content: "Agent response here".to_string(),
                     content_html: "<p>Agent response here</p>\n".to_string(),
                     timestamp: "12:35:00".to_string(),
+                    repeat_count: 1,
                 },
             ],
             pending_question: None,

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -2228,16 +2228,9 @@ pub async fn transition_phase(
         .await
     {
         Ok(_) => {
-            let label = match target {
-                SpecPhase::Brainstorming => "Brainstorming",
-                SpecPhase::Refining => "Refining",
-                SpecPhase::Complete => "Complete",
-            };
-            (
-                StatusCode::OK,
-                Html(format!("<span class=\"phase-badge\">{}</span>", label)),
-            )
-                .into_response()
+            // Phase transition triggers SSE phase_transitioned event,
+            // which causes the client to reload the entire workspace.
+            (StatusCode::OK, Html("<span>OK</span>".to_string())).into_response()
         }
         Err(ActorError::AlreadyInPhase) => (
             StatusCode::CONFLICT,
@@ -4990,20 +4983,20 @@ mod tests {
             "should have brainstorming marker"
         );
         assert!(
-            html.contains("phase-brainstorming"),
-            "should have brainstorming badge"
+            html.contains("phase-stepper"),
+            "should have phase stepper"
         );
         assert!(
-            html.contains("View Board"),
-            "should have View Board button"
+            html.contains("step-active"),
+            "should have active stepper step"
         );
         assert!(
             html.contains("agent-canvas"),
             "should have agent-canvas container"
         );
         assert!(
-            !html.contains("Resume Brainstorming"),
-            "should not have Resume button in brainstorming"
+            !html.contains("view-toggles-row"),
+            "brainstorming should not have view toggles row"
         );
     }
 
@@ -5054,16 +5047,20 @@ mod tests {
             "should have document tab toggle"
         );
         assert!(
-            html.contains("Resume Brainstorming"),
-            "should have Resume button"
+            html.contains("view-toggles-row"),
+            "refining should have view toggles row"
+        );
+        assert!(
+            html.contains("phase-stepper"),
+            "should have phase stepper"
+        );
+        assert!(
+            html.contains("step-completed"),
+            "brainstorming step should be completed in refining phase"
         );
         assert!(
             !html.contains("data-view=\"brainstorming\""),
             "should not have brainstorming marker"
-        );
-        assert!(
-            !html.contains("phase-brainstorming"),
-            "should not have brainstorming badge"
         );
     }
 

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -1608,14 +1608,16 @@ pub async fn artifacts(
     .into_response()
 }
 
-/// Workflow tab template showing a placeholder for DAG visualization.
+/// Spec tab template showing a synthesized specification document.
 #[derive(Template, AskamaIntoResponse)]
 #[template(path = "partials/spec.html")]
 pub struct SpecTabTemplate {
     pub spec_id: String,
+    pub spec_html: String,
+    pub spec_markdown: String,
 }
 
-/// GET /web/specs/{id}/spec - Render the Workflow tab placeholder.
+/// GET /web/specs/{id}/spec - Render the synthesized Spec tab.
 pub async fn spec(
     State(state): State<SharedState>,
     Path(id): Path<String>,
@@ -1626,16 +1628,25 @@ pub async fn spec(
     };
 
     let actors = state.actors.read().await;
-    if !actors.contains_key(&spec_id) {
-        return (
-            StatusCode::NOT_FOUND,
-            Html("<p class=\"error-msg\">Spec not found.</p>".to_string()),
-        )
-            .into_response();
-    }
+    let handle = match actors.get(&spec_id) {
+        Some(h) => h,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Html("<p class=\"error-msg\">Spec not found.</p>".to_string()),
+            )
+                .into_response();
+        }
+    };
+
+    let spec_state = handle.read_state().await;
+    let spec_markdown = barnstormer_core::export::export_spec(&spec_state);
+    let spec_html = render_markdown(&spec_markdown);
 
     SpecTabTemplate {
         spec_id: id,
+        spec_html,
+        spec_markdown,
     }
     .into_response()
 }
@@ -4204,8 +4215,8 @@ mod tests {
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(
-            html.contains("workflow-placeholder"),
-            "spec response should contain workflow-placeholder class: {}",
+            html.contains("spec-document"),
+            "spec response should contain spec-document class: {}",
             html
         );
     }
@@ -4227,14 +4238,26 @@ mod tests {
     }
 
     #[test]
-    fn spec_template_renders_workflow_placeholder() {
+    fn spec_template_renders_with_content() {
         let tmpl = SpecTabTemplate {
             spec_id: "01HTEST".to_string(),
+            spec_html: "<h1>Test</h1>".to_string(),
+            spec_markdown: "# Test".to_string(),
         };
         let rendered = tmpl.render().unwrap();
-        assert!(rendered.contains("workflow-placeholder"), "should contain workflow-placeholder class");
-        assert!(rendered.contains("Download DOT"), "should contain DOT download link");
-        assert!(rendered.contains("Pipeline Structure"), "should contain pipeline structure heading");
+        assert!(rendered.contains("spec-document"), "should contain spec-document class");
+        assert!(rendered.contains("spec-copy-md"), "should contain copy markdown button");
+    }
+
+    #[test]
+    fn spec_template_renders_empty_state() {
+        let tmpl = SpecTabTemplate {
+            spec_id: "01HTEST".to_string(),
+            spec_html: String::new(),
+            spec_markdown: String::new(),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(rendered.contains("spec-document"));
     }
 
     // ---- Export download tests ----

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -3893,7 +3893,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_panel_contains_header_and_transcript() {
+    fn chat_panel_contains_transcript_and_input() {
         let tmpl = ChatPanelTemplate {
             spec_id: "01HTEST".to_string(),
             container_id: "chat-transcript".to_string(),
@@ -3902,9 +3902,9 @@ mod tests {
             pending_question: None,
         };
         let rendered = tmpl.render().unwrap();
-        assert!(rendered.contains("chat-panel-header"), "should contain chat panel header");
-        assert!(rendered.contains("Chat"), "should contain Chat title");
+        assert!(rendered.contains("chat-panel"), "should contain chat-panel wrapper");
         assert!(rendered.contains("sse:transcript_appended"), "should listen for transcript_appended event");
+        assert!(rendered.contains("chat-input-area"), "should contain input area");
     }
 
     #[tokio::test]

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -3537,7 +3537,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_status_template_renders_paused() {
+    fn agent_status_template_renders_paused_as_stopped() {
         let tmpl = AgentStatusTemplate {
             spec_id: "01HTEST".to_string(),
             running: false,
@@ -3545,9 +3545,10 @@ mod tests {
             agent_count: 4,
         };
         let rendered = tmpl.render().unwrap();
-        assert!(rendered.contains("agent-pill-paused"), "should have paused pill class");
-        assert!(rendered.contains("Agents paused"), "should show paused state");
-        assert!(rendered.contains("/agents/resume"), "should have resume action URL");
+        assert!(rendered.contains("agent-pill-stopped"), "paused should render as stopped pill");
+        assert!(rendered.contains("Start agents"), "paused should show start agents text");
+        assert!(rendered.contains("/agents/resume"), "paused should resume on click");
+        assert!(!rendered.contains("agent-pill-paused"), "should not have separate paused state");
     }
 
     #[tokio::test]

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -1295,9 +1295,12 @@ fn question_to_view_data(q: &barnstormer_core::UserQuestion) -> QuestionData {
 
 /// Query parameters for the transcript endpoint, allowing callers to specify
 /// which container the response should target (activity panel vs chat tab).
+/// The optional `part` field selects a sub-section: "feed" for messages only,
+/// "question" for the question card only, or omitted for the full transcript.
 #[derive(Deserialize)]
 pub struct TranscriptQuery {
     pub container_id: Option<String>,
+    pub part: Option<String>,
 }
 
 /// Validate and sanitize a container_id value. Only known IDs are accepted;
@@ -1430,7 +1433,23 @@ pub async fn activity_transcript(
     mark_continuations(&mut transcript);
     collapse_repeated_steps(&mut transcript);
 
-    if is_chat {
+    let part = query.part.as_deref().unwrap_or("");
+
+    if is_chat && part == "feed" {
+        ChatFeedTemplate {
+            spec_id: id,
+            container_id,
+            transcript,
+        }
+        .into_response()
+    } else if is_chat && part == "question" {
+        ChatQuestionTemplate {
+            spec_id: id,
+            container_id,
+            pending_question,
+        }
+        .into_response()
+    } else if is_chat {
         ChatTranscriptTemplate {
             spec_id: id,
             container_id,
@@ -1457,6 +1476,26 @@ pub struct ChatTranscriptTemplate {
     pub spec_id: String,
     pub container_id: String,
     pub transcript: Vec<TranscriptEntry>,
+    pub pending_question: Option<QuestionData>,
+}
+
+/// Chat message feed partial — messages, throbber, streaming, empty state.
+/// Rendered independently so transcript refreshes don't disturb the question card.
+#[derive(Template, AskamaIntoResponse)]
+#[template(path = "partials/chat_feed.html")]
+pub struct ChatFeedTemplate {
+    pub spec_id: String,
+    pub container_id: String,
+    pub transcript: Vec<TranscriptEntry>,
+}
+
+/// Chat question card partial — pending question with answer form.
+/// Rendered independently so question refreshes don't disturb the message feed.
+#[derive(Template, AskamaIntoResponse)]
+#[template(path = "partials/chat_question.html")]
+pub struct ChatQuestionTemplate {
+    pub spec_id: String,
+    pub container_id: String,
     pub pending_question: Option<QuestionData>,
 }
 
@@ -1923,13 +1962,21 @@ pub async fn answer_question(
 
     // Determine container_id from HX-Target header so the response replaces
     // the correct transcript container (activity panel vs chat tab).
-    let container_id = sanitize_container_id(
-        headers
-            .get("HX-Target")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.trim_start_matches('#'))
-            .unwrap_or("activity-transcript"),
-    );
+    // If the target ends with "-question", we return only the question card
+    // partial so the message feed is untouched.
+    let raw_target = headers
+        .get("HX-Target")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim_start_matches('#'))
+        .unwrap_or("activity-transcript");
+
+    let is_question_target = raw_target.ends_with("-question");
+    let base_target = if is_question_target {
+        raw_target.trim_end_matches("-question")
+    } else {
+        raw_target
+    };
+    let container_id = sanitize_container_id(base_target);
 
     // Return refreshed transcript partial
     let spec_state = handle.read_state().await;
@@ -1940,6 +1987,17 @@ pub async fn answer_question(
 
     // Read actual pending question from state instead of assuming None
     let pending_question = spec_state.pending_question.as_ref().map(question_to_view_data);
+
+    // If the answer form targeted the question card directly, return only
+    // the question partial so the message feed and any user input are preserved.
+    if is_question_target && is_chat {
+        return ChatQuestionTemplate {
+            spec_id: id,
+            container_id,
+            pending_question,
+        }
+        .into_response();
+    }
 
     let mut transcript: Vec<TranscriptEntry> = spec_state
         .transcript
@@ -4700,6 +4758,499 @@ mod tests {
             html.contains(r#"id="chat-transcript""#),
             "response should target chat-transcript container: {}",
             html
+        );
+    }
+
+    // ---- Chat feed / question split template tests ----
+
+    #[test]
+    fn chat_feed_template_renders_empty() {
+        let tmpl = ChatFeedTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            transcript: vec![],
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains(r#"id="chat-transcript-feed""#),
+            "should contain feed container id"
+        );
+        assert!(
+            rendered.contains("No messages yet"),
+            "empty feed should show empty state"
+        );
+        assert!(
+            rendered.contains("sse:transcript_appended"),
+            "feed should trigger on transcript_appended"
+        );
+        assert!(
+            !rendered.contains("chat-question-card"),
+            "feed should not contain question card"
+        );
+    }
+
+    #[test]
+    fn chat_feed_template_renders_with_entries() {
+        let tmpl = ChatFeedTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            transcript: vec![TranscriptEntry {
+                sender: "human".to_string(),
+                sender_label: "You".to_string(),
+                initial: "Y".to_string(),
+                is_human: true,
+                is_step: false,
+                is_continuation: false,
+                role_class: "human".to_string(),
+                content: "Hello world".to_string(),
+                content_html: "<p>Hello world</p>\n".to_string(),
+                timestamp: "12:00:00".to_string(),
+                repeat_count: 1,
+            }],
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(rendered.contains("Hello world"));
+        assert!(rendered.contains("You"), "should contain sender label");
+        assert!(
+            !rendered.contains("No messages yet"),
+            "should not show empty state when entries exist"
+        );
+    }
+
+    #[test]
+    fn chat_feed_template_contains_part_feed_in_hx_get() {
+        let tmpl = ChatFeedTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "brainstorm-chat".to_string(),
+            transcript: vec![],
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains("part=feed"),
+            "feed hx-get should include part=feed param"
+        );
+        assert!(
+            rendered.contains("container_id=brainstorm-chat"),
+            "feed hx-get should include container_id param"
+        );
+    }
+
+    #[test]
+    fn chat_question_template_renders_no_question() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: None,
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains(r#"id="chat-transcript-question""#),
+            "should contain question container id"
+        );
+        assert!(
+            !rendered.contains("chat-question-card"),
+            "should not render question card when no question pending"
+        );
+        assert!(
+            rendered.contains("sse:question_asked"),
+            "question container should trigger on question_asked"
+        );
+    }
+
+    #[test]
+    fn chat_question_template_renders_boolean_question() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: Some(QuestionData::Boolean {
+                question_id: "01HQID".to_string(),
+                question: "Continue?".to_string(),
+                default: Some(true),
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(rendered.contains("Continue?"));
+        assert!(rendered.contains("Yes"));
+        assert!(rendered.contains("No"));
+        assert!(
+            rendered.contains("Something else"),
+            "boolean question should have 'Something else' option"
+        );
+    }
+
+    #[test]
+    fn chat_question_template_renders_freeform_question() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: Some(QuestionData::Freeform {
+                question_id: "01HQID".to_string(),
+                question: "Describe the goal".to_string(),
+                placeholder: "Enter goal...".to_string(),
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(rendered.contains("Describe the goal"));
+        assert!(rendered.contains("Enter goal..."));
+    }
+
+    #[test]
+    fn chat_question_template_renders_multiple_choice() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: Some(QuestionData::MultipleChoice {
+                question_id: "01HQID".to_string(),
+                question: "Pick a language".to_string(),
+                choices: vec!["Rust".to_string(), "Python".to_string()],
+                allow_multi: false,
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(rendered.contains("Pick a language"));
+        assert!(rendered.contains("Rust"));
+        assert!(rendered.contains("Python"));
+    }
+
+    #[test]
+    fn chat_question_template_targets_question_container() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: Some(QuestionData::Boolean {
+                question_id: "01HQID".to_string(),
+                question: "Proceed?".to_string(),
+                default: None,
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains(r##"hx-target="#chat-transcript-question""##),
+            "answer form should target question container, not full transcript: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn chat_question_template_contains_part_question_in_hx_get() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: None,
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains("part=question"),
+            "question hx-get should include part=question param"
+        );
+    }
+
+    #[test]
+    fn chat_question_boolean_has_options_set_wrapper() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: Some(QuestionData::Boolean {
+                question_id: "01HQID".to_string(),
+                question: "Continue?".to_string(),
+                default: None,
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains("chat-options-set"),
+            "boolean question should wrap options in chat-options-set: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("chat-else-back"),
+            "boolean question should have a back button: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn chat_question_multiple_choice_has_options_set_wrapper() {
+        let tmpl = ChatQuestionTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            pending_question: Some(QuestionData::MultipleChoice {
+                question_id: "01HQID".to_string(),
+                question: "Pick one".to_string(),
+                choices: vec!["A".to_string(), "B".to_string()],
+                allow_multi: false,
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains("chat-options-set"),
+            "multiple choice question should wrap options in chat-options-set: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("chat-else-back"),
+            "multiple choice question should have a back button: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn chat_transcript_wrapper_defines_toggle_else_helper() {
+        let tmpl = ChatTranscriptTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            transcript: vec![],
+            pending_question: None,
+        };
+        let rendered = tmpl.render().unwrap();
+        assert!(
+            rendered.contains("function toggleElse"),
+            "wrapper script should define toggleElse helper function: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn chat_transcript_template_includes_feed_and_question() {
+        let tmpl = ChatTranscriptTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            transcript: vec![TranscriptEntry {
+                sender: "human".to_string(),
+                sender_label: "You".to_string(),
+                initial: "Y".to_string(),
+                is_human: true,
+                is_step: false,
+                is_continuation: false,
+                role_class: "human".to_string(),
+                content: "Test message".to_string(),
+                content_html: "<p>Test message</p>\n".to_string(),
+                timestamp: "12:00:00".to_string(),
+                repeat_count: 1,
+            }],
+            pending_question: Some(QuestionData::Boolean {
+                question_id: "01HQID".to_string(),
+                question: "Ready?".to_string(),
+                default: None,
+            }),
+        };
+        let rendered = tmpl.render().unwrap();
+        // Wrapper container
+        assert!(
+            rendered.contains(r#"id="chat-transcript""#),
+            "should have wrapper container id"
+        );
+        // Feed sub-container
+        assert!(
+            rendered.contains(r#"id="chat-transcript-feed""#),
+            "should include feed sub-container"
+        );
+        // Question sub-container
+        assert!(
+            rendered.contains(r#"id="chat-transcript-question""#),
+            "should include question sub-container"
+        );
+        // Content from both
+        assert!(rendered.contains("Test message"), "should contain transcript entry");
+        assert!(rendered.contains("Ready?"), "should contain question");
+    }
+
+    #[test]
+    fn chat_transcript_template_feed_and_question_have_independent_triggers() {
+        let tmpl = ChatTranscriptTemplate {
+            spec_id: "01HTEST".to_string(),
+            container_id: "chat-transcript".to_string(),
+            transcript: vec![],
+            pending_question: None,
+        };
+        let rendered = tmpl.render().unwrap();
+        // The wrapper div itself should NOT have hx-trigger (only children do)
+        // Feed triggers on transcript_appended only
+        assert!(
+            rendered.contains("sse:transcript_appended"),
+            "feed should have transcript_appended trigger"
+        );
+        // Question triggers on question_asked and question_answered
+        assert!(
+            rendered.contains("sse:question_asked"),
+            "question should have question_asked trigger"
+        );
+        assert!(
+            rendered.contains("sse:question_answered"),
+            "question should have question_answered trigger"
+        );
+    }
+
+    // ---- Handler tests for part=feed and part=question ----
+
+    #[tokio::test]
+    async fn activity_transcript_with_part_feed_returns_feed_only() {
+        let state = test_state();
+
+        let app = create_router(Arc::clone(&state), None);
+        let resp = app
+            .oneshot(
+                Request::post("/web/specs")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("description=Feed+part+test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let spec_id = {
+            let actors = state.actors.read().await;
+            *actors.keys().next().expect("should have a spec")
+        };
+
+        let app2 = create_router(Arc::clone(&state), None);
+        let resp = app2
+            .oneshot(
+                Request::get(format!(
+                    "/web/specs/{}/activity/transcript?container_id=chat-transcript&part=feed",
+                    spec_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(r#"id="chat-transcript-feed""#),
+            "should return feed container: {}",
+            html
+        );
+        assert!(
+            !html.contains(r#"id="chat-transcript-question""#),
+            "should not include question container in feed-only response"
+        );
+    }
+
+    #[tokio::test]
+    async fn activity_transcript_with_part_question_returns_question_only() {
+        let state = test_state();
+
+        let app = create_router(Arc::clone(&state), None);
+        let resp = app
+            .oneshot(
+                Request::post("/web/specs")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("description=Question+part+test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let spec_id = {
+            let actors = state.actors.read().await;
+            *actors.keys().next().expect("should have a spec")
+        };
+
+        let app2 = create_router(Arc::clone(&state), None);
+        let resp = app2
+            .oneshot(
+                Request::get(format!(
+                    "/web/specs/{}/activity/transcript?container_id=chat-transcript&part=question",
+                    spec_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(r#"id="chat-transcript-question""#),
+            "should return question container: {}",
+            html
+        );
+        assert!(
+            !html.contains(r#"id="chat-transcript-feed""#),
+            "should not include feed container in question-only response"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_answer_targeting_question_container_returns_question_only() {
+        let state = test_state();
+
+        let app = create_router(Arc::clone(&state), None);
+        let resp = app
+            .oneshot(
+                Request::post("/web/specs")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from("description=Answer+question+target+test"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let spec_id = {
+            let actors = state.actors.read().await;
+            *actors.keys().next().expect("should have a spec")
+        };
+
+        // Ask a question so we can answer it
+        let question_id = ulid::Ulid::new();
+        {
+            let actors = state.actors.read().await;
+            let handle = actors.get(&spec_id).expect("actor should exist");
+            handle
+                .send_command(Command::AskQuestion {
+                    question: barnstormer_core::UserQuestion::Freeform {
+                        question_id,
+                        question: "What color?".to_string(),
+                        placeholder: None,
+                        validation_hint: None,
+                    },
+                })
+                .await
+                .unwrap();
+        }
+
+        // POST to /answer with HX-Target: #chat-transcript-question
+        let app2 = create_router(Arc::clone(&state), None);
+        let resp = app2
+            .oneshot(
+                Request::post(format!("/web/specs/{}/answer", spec_id))
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("HX-Target", "#chat-transcript-question")
+                    .body(Body::from(format!(
+                        "question_id={}&answer=Blue",
+                        question_id
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains(r#"id="chat-transcript-question""#),
+            "response should be the question container only: {}",
+            html
+        );
+        assert!(
+            !html.contains(r#"id="chat-transcript-feed""#),
+            "response should not include the feed container"
         );
     }
 

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -1490,16 +1490,14 @@ pub async fn artifacts(
     .into_response()
 }
 
-/// Spec tab template showing a synthesized specification document.
+/// Workflow tab template showing a placeholder for DAG visualization.
 #[derive(Template, AskamaIntoResponse)]
 #[template(path = "partials/spec.html")]
 pub struct SpecTabTemplate {
     pub spec_id: String,
-    pub spec_html: String,
-    pub spec_markdown: String,
 }
 
-/// GET /web/specs/{id}/spec - Render the synthesized Spec tab.
+/// GET /web/specs/{id}/spec - Render the Workflow tab placeholder.
 pub async fn spec(
     State(state): State<SharedState>,
     Path(id): Path<String>,
@@ -1510,25 +1508,16 @@ pub async fn spec(
     };
 
     let actors = state.actors.read().await;
-    let handle = match actors.get(&spec_id) {
-        Some(h) => h,
-        None => {
-            return (
-                StatusCode::NOT_FOUND,
-                Html("<p class=\"error-msg\">Spec not found.</p>".to_string()),
-            )
-                .into_response();
-        }
-    };
-
-    let spec_state = handle.read_state().await;
-    let spec_markdown = barnstormer_core::export::export_spec(&spec_state);
-    let spec_html = render_markdown(&spec_markdown);
+    if !actors.contains_key(&spec_id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Html("<p class=\"error-msg\">Spec not found.</p>".to_string()),
+        )
+            .into_response();
+    }
 
     SpecTabTemplate {
         spec_id: id,
-        spec_html,
-        spec_markdown,
     }
     .into_response()
 }
@@ -4046,8 +4035,8 @@ mod tests {
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(
-            html.contains("spec-document"),
-            "spec response should contain spec-document class: {}",
+            html.contains("workflow-placeholder"),
+            "spec response should contain workflow-placeholder class: {}",
             html
         );
     }
@@ -4069,26 +4058,14 @@ mod tests {
     }
 
     #[test]
-    fn spec_template_renders_with_content() {
+    fn spec_template_renders_workflow_placeholder() {
         let tmpl = SpecTabTemplate {
             spec_id: "01HTEST".to_string(),
-            spec_html: "<h1>Test</h1>".to_string(),
-            spec_markdown: "# Test".to_string(),
         };
         let rendered = tmpl.render().unwrap();
-        assert!(rendered.contains("spec-document"), "should contain spec-document class");
-        assert!(rendered.contains("spec-copy-md"), "should contain copy markdown button");
-    }
-
-    #[test]
-    fn spec_template_renders_empty_state() {
-        let tmpl = SpecTabTemplate {
-            spec_id: "01HTEST".to_string(),
-            spec_html: String::new(),
-            spec_markdown: String::new(),
-        };
-        let rendered = tmpl.render().unwrap();
-        assert!(rendered.contains("spec-document"));
+        assert!(rendered.contains("workflow-placeholder"), "should contain workflow-placeholder class");
+        assert!(rendered.contains("Download DOT"), "should contain DOT download link");
+        assert!(rendered.contains("Pipeline Structure"), "should contain pipeline structure heading");
     }
 
     // ---- Export download tests ----

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -2180,6 +2180,32 @@ pub async fn transition_phase(
     }
 }
 
+/// Returns the current phase as plain text — used by the client-side
+/// polling fallback when SSE might be disconnected.
+pub async fn phase_check(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let spec_id = match parse_spec_id(&id) {
+        Ok(id) => id,
+        Err(resp) => return *resp,
+    };
+    let actors = state.actors.read().await;
+    let handle = match actors.get(&spec_id) {
+        Some(h) => h,
+        None => {
+            return (StatusCode::NOT_FOUND, "not_found").into_response();
+        }
+    };
+    let spec_state = handle.read_state().await;
+    let phase_str = match spec_state.phase {
+        SpecPhase::Brainstorming => "brainstorming",
+        SpecPhase::Refining => "refining",
+        SpecPhase::Complete => "complete",
+    };
+    phase_str.into_response()
+}
+
 /// Provider status partial template.
 #[derive(Template, AskamaIntoResponse)]
 #[template(path = "partials/provider_status.html")]

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -578,6 +578,28 @@ pub struct SpecViewTemplate {
     pub has_pending_question: bool,
 }
 
+impl SpecViewTemplate {
+    /// A phase is "completed" if the current phase is further along in the lifecycle.
+    fn is_completed(&self, phase_id: &str) -> bool {
+        let order = |p: &str| match p {
+            "brainstorming" => 0,
+            "refining" => 1,
+            "complete" => 2,
+            _ => 99,
+        };
+        order(phase_id) < order(&self.phase)
+    }
+
+    /// Tooltip text explaining why a future phase is disabled.
+    fn disabled_tooltip(&self, phase_id: &str) -> &'static str {
+        match phase_id {
+            "refining" => "Complete brainstorming to unlock refining",
+            "complete" => "Refine the spec before finalizing",
+            _ => "",
+        }
+    }
+}
+
 /// Full-page spec view for direct navigation / page reload (non-HTMX requests).
 #[derive(Template, AskamaIntoResponse)]
 #[template(path = "spec_page.html")]
@@ -590,6 +612,28 @@ pub struct SpecPageTemplate {
     pub lanes: Vec<LaneData>,
     pub canvas_content: Option<String>,
     pub has_pending_question: bool,
+}
+
+impl SpecPageTemplate {
+    /// A phase is "completed" if the current phase is further along in the lifecycle.
+    fn is_completed(&self, phase_id: &str) -> bool {
+        let order = |p: &str| match p {
+            "brainstorming" => 0,
+            "refining" => 1,
+            "complete" => 2,
+            _ => 99,
+        };
+        order(phase_id) < order(&self.phase)
+    }
+
+    /// Tooltip text explaining why a future phase is disabled.
+    fn disabled_tooltip(&self, phase_id: &str) -> &'static str {
+        match phase_id {
+            "refining" => "Complete brainstorming to unlock refining",
+            "complete" => "Refine the spec before finalizing",
+            _ => "",
+        }
+    }
 }
 
 /// GET /web/specs/{id} - Render the spec compositor (command bar + canvas + chat rail).

--- a/crates/barnstormer-server/src/web/mod.rs
+++ b/crates/barnstormer-server/src/web/mod.rs
@@ -1237,9 +1237,15 @@ pub struct TranscriptQuery {
 /// Validate and sanitize a container_id value. Only known IDs are accepted;
 /// anything else falls back to "chat-transcript" to prevent XSS via
 /// user-controlled values rendered into script tags and HTMX attributes.
+///
+/// Allowed IDs and where they are used:
+/// - "activity-transcript" -- activity panel transcript (default for activity handlers)
+/// - "chat-transcript"     -- chat panel transcript in refining phase
+/// - "brainstorm-chat"     -- chat panel transcript in brainstorming phase
+/// - "mission-ticker"      -- compact ticker strip; also the hx-target for answer forms
 fn sanitize_container_id(raw: &str) -> String {
     match raw {
-        "activity-transcript" | "chat-transcript" | "mission-ticker" | "canvas" | "chat-rail" | "brainstorm-chat" => {
+        "activity-transcript" | "chat-transcript" | "mission-ticker" | "brainstorm-chat" => {
             raw.to_string()
         }
         _ => "chat-transcript".to_string(),
@@ -1342,6 +1348,9 @@ pub async fn activity_transcript(
         query.container_id.as_deref().unwrap_or("activity-transcript"),
     );
 
+    // Chat containers only show human + manager messages (filtered by
+    // is_chat_participant) so the user sees a clean conversation thread.
+    // The activity-transcript and mission-ticker containers show all senders.
     let is_chat = container_id == "chat-transcript" || container_id == "brainstorm-chat";
 
     let mut transcript: Vec<TranscriptEntry> = spec_state
@@ -1855,6 +1864,7 @@ pub async fn answer_question(
     // Return refreshed transcript partial
     let spec_state = handle.read_state().await;
 
+    // Chat containers only show human + manager messages; see sanitize_container_id docs.
     let is_chat = container_id == "chat-transcript" || container_id == "brainstorm-chat";
     let is_ticker = container_id == "mission-ticker";
 
@@ -2012,6 +2022,7 @@ pub async fn chat(
     // Return refreshed transcript partial
     let spec_state = handle.read_state().await;
 
+    // Chat containers only show human + manager messages; see sanitize_container_id docs.
     let is_chat = container_id == "chat-transcript" || container_id == "brainstorm-chat";
     let is_ticker = container_id == "mission-ticker";
 
@@ -4370,8 +4381,10 @@ mod tests {
         assert_eq!(sanitize_container_id("activity-transcript"), "activity-transcript");
         assert_eq!(sanitize_container_id("chat-transcript"), "chat-transcript");
         assert_eq!(sanitize_container_id("mission-ticker"), "mission-ticker");
-        assert_eq!(sanitize_container_id("canvas"), "canvas");
-        assert_eq!(sanitize_container_id("chat-rail"), "chat-rail");
+        assert_eq!(sanitize_container_id("brainstorm-chat"), "brainstorm-chat");
+        // IDs that are DOM element IDs but not transcript container_ids should be rejected.
+        assert_eq!(sanitize_container_id("canvas"), "chat-transcript");
+        assert_eq!(sanitize_container_id("chat-rail"), "chat-transcript");
         assert_eq!(sanitize_container_id("'); alert('xss'); //"), "chat-transcript");
         assert_eq!(sanitize_container_id("malicious-id"), "chat-transcript");
         assert_eq!(sanitize_container_id(""), "chat-transcript");

--- a/crates/barnstormer-store/src/manager.rs
+++ b/crates/barnstormer-store/src/manager.rs
@@ -165,7 +165,7 @@ mod tests {
             undo_stack: Vec::new(),
             last_event_id: 0,
             lanes: vec!["Ideas".to_string(), "Plan".to_string(), "Spec".to_string()],
-            phase: SpecPhase::Active,
+            phase: SpecPhase::Refining,
             canvas_content: None,
         }
     }

--- a/docs/plans/2026-04-16-streaming-design.md
+++ b/docs/plans/2026-04-16-streaming-design.md
@@ -1,0 +1,98 @@
+# Token Streaming & Live Agent Activity Design
+
+**Goal:** Stream the manager agent's LLM responses token-by-token to the chat UI, and show a live "what's happening now" status line for worker agent activity.
+
+**Approach:** Ephemeral events through the existing event broadcast → SSE pipeline. No new transport mechanisms.
+
+**Tech Stack:** Rust (mux Hook trait, Axum SSE), JavaScript (EventSource listeners, DOM manipulation).
+
+---
+
+## 1. Ephemeral Events
+
+Two new variants added to `EventPayload` and `Command`:
+
+- **`StreamingDelta { agent_id: String, text: String }`** — a text fragment from the manager's LLM response.
+- **`StreamingToolActivity { agent_id: String, activity: String }`** — a one-line description of what a worker is currently doing (e.g., "Researcher: creating card 'Auth Flow'").
+
+These are **ephemeral**: the state reducer's `apply()` ignores them (no state mutation), and the persister skips them (no JSONL write). They exist solely to ride the broadcast channel to SSE subscribers.
+
+An `is_ephemeral()` method on `EventPayload` lets the persister check before writing.
+
+## 2. Mux Hook Implementation
+
+A `StreamingHook` struct in `barnstormer-agent` implements the mux `Hook` trait, constructed with an `Arc<SpecActorHandle>`.
+
+**Manager agent (streaming enabled):**
+- `HookEvent::StreamDelta { text, .. }` → sends `Command::StreamingDelta { agent_id, text }`
+
+**All agents (manager + workers):**
+- `HookEvent::PostToolUse { tool_name, result, .. }` → sends `Command::StreamingToolActivity { agent_id, activity }` with a short description.
+- `HookEvent::Iteration { .. }` → sends `StreamingToolActivity` with `"<agent>: thinking..."`.
+
+Wiring in `swarm.rs`:
+- Build a `HookRegistry` containing `StreamingHook`.
+- Call `.with_hooks(hook_registry)` on SubAgent.
+- Call `.streaming(true)` on `AgentDefinition` **only for the manager agent** (workers get hook callbacks but not token streaming).
+
+## 3. SSE Event Mapping
+
+Two new SSE event names in `stream.rs`:
+- `StreamingDelta` → `"streaming_delta"`
+- `StreamingToolActivity` → `"streaming_tool_activity"`
+
+Same SSE pipe as all other events. No new endpoints. HTMX `hx-trigger` does NOT include these — JavaScript SSE listeners handle them directly (same pattern as the throbber).
+
+## 4. Client-Side Rendering
+
+### Manager token streaming (chat panel)
+
+1. **First `streaming_delta`:** Hide throbber, create a new `.chat-message` div with manager avatar and empty `.chat-body`. Append to chat feed.
+2. **Subsequent `streaming_delta`:** Append `text` to `.chat-body`'s `textContent`. Auto-scroll.
+3. **`transcript_appended`:** HTMX re-fetches the full transcript, replacing the streaming placeholder with authoritative server-rendered HTML (with proper markdown formatting).
+
+Streaming text is raw/unformatted while typing, then "snaps" to formatted HTML on completion. Standard chat UX pattern.
+
+### Worker activity status line
+
+1. A `<div id="{{container_id}}-activity" class="chat-activity-status">` sits below the throbber area.
+2. On `streaming_tool_activity`: show element, overwrite text content with `activity` string.
+3. On `agent_step_finished`: hide the element.
+4. On `streaming_delta` from manager: also hide (manager is talking, worker status irrelevant).
+
+Each `streaming_tool_activity` overwrites the previous — "tail -n 1" behavior. No accumulation.
+
+## 5. Error Handling & Edge Cases
+
+- **SSE drop mid-stream:** Orphaned partial text gets replaced on next HTMX transcript swap. Self-healing.
+- **Broadcast lag:** Streaming deltas are high-frequency but tiny. If lagged, SSE silently drops them. Final `transcript_appended` delivers the complete message.
+- **Workers with no tool calls:** `Iteration` hook fires "thinking..." until a tool call happens. `agent_step_finished` clears the status line.
+- **No new failure modes.** Everything degrades gracefully to existing non-streaming behavior.
+
+## 6. Testing
+
+**Unit tests (barnstormer-core):**
+- Round-trip serialization for both new event payloads.
+- `is_ephemeral()` returns true for new variants, false for existing.
+- `state.apply()` is a no-op for ephemeral events.
+
+**Unit tests (barnstormer-agent):**
+- `StreamingHook` sends correct commands for `StreamDelta`, `PostToolUse`, `Iteration` hook events.
+- Hook `accepts()` filters correctly.
+
+**Integration test (barnstormer-server):**
+- SSE stream receives `streaming_delta` and `streaming_tool_activity` events.
+- Persister skips ephemeral events (not written to JSONL).
+
+## Files Touched
+
+- `crates/barnstormer-core/src/event.rs` — new EventPayload variants, `is_ephemeral()`
+- `crates/barnstormer-core/src/command.rs` — new Command variants
+- `crates/barnstormer-core/src/state.rs` — no-op apply arms for ephemeral events
+- `crates/barnstormer-core/src/actor.rs` — command_to_events for new commands
+- `crates/barnstormer-agent/src/streaming_hook.rs` — new file, StreamingHook implementation
+- `crates/barnstormer-agent/src/swarm.rs` — wire hooks + .streaming(true) for manager
+- `crates/barnstormer-server/src/api/stream.rs` — new event_type_name arms
+- `crates/barnstormer-server/src/web/mod.rs` — persister skip for ephemeral events
+- `templates/partials/chat_transcript.html` — streaming div, activity status line, JS listeners
+- `static/style.css` — streaming message + activity status styling

--- a/docs/plans/2026-04-16-streaming-implementation.md
+++ b/docs/plans/2026-04-16-streaming-implementation.md
@@ -1,0 +1,868 @@
+# Token Streaming & Live Agent Activity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stream the manager agent's LLM responses token-by-token to the chat UI and show a live worker activity status line, using ephemeral events through the existing broadcast → SSE pipeline.
+
+**Architecture:** Two new ephemeral `EventPayload` variants (`StreamingDelta`, `StreamingToolActivity`) ride the broadcast channel to SSE but are ignored by the state reducer and persister. A `StreamingHook` in barnstormer-agent implements the mux `Hook` trait to bridge LLM streaming callbacks to the actor's command channel. The browser handles rendering via JavaScript SSE listeners.
+
+**Tech Stack:** Rust (mux Hook trait, Axum SSE, Askama templates), JavaScript (EventSource listeners, DOM manipulation), CSS.
+
+**Design doc:** `docs/plans/2026-04-16-streaming-design.md`
+
+---
+
+### Task 1: Add ephemeral event variants to barnstormer-core
+
+Add `StreamingDelta` and `StreamingToolActivity` to `Command`, `EventPayload`, the actor's command handler, and the state reducer. Add `is_ephemeral()` to `EventPayload`.
+
+**Files:**
+- Modify: `crates/barnstormer-core/src/command.rs`
+- Modify: `crates/barnstormer-core/src/event.rs`
+- Modify: `crates/barnstormer-core/src/actor.rs`
+- Modify: `crates/barnstormer-core/src/state.rs`
+
+**Step 1: Write failing tests**
+
+In `crates/barnstormer-core/src/event.rs`, add two serialization round-trip tests at the bottom of the `mod tests` block:
+
+```rust
+#[test]
+fn streaming_delta_round_trip() {
+    round_trip_event(EventPayload::StreamingDelta {
+        agent_id: "manager-1".to_string(),
+        text: "Hello".to_string(),
+    });
+}
+
+#[test]
+fn streaming_tool_activity_round_trip() {
+    round_trip_event(EventPayload::StreamingToolActivity {
+        agent_id: "brainstormer-1".to_string(),
+        activity: "creating card 'Auth Flow'".to_string(),
+    });
+}
+
+#[test]
+fn is_ephemeral_returns_true_for_streaming_events() {
+    assert!(EventPayload::StreamingDelta {
+        agent_id: String::new(),
+        text: String::new(),
+    }.is_ephemeral());
+    assert!(EventPayload::StreamingToolActivity {
+        agent_id: String::new(),
+        activity: String::new(),
+    }.is_ephemeral());
+}
+
+#[test]
+fn is_ephemeral_returns_false_for_durable_events() {
+    assert!(!EventPayload::SpecCreated {
+        title: String::new(),
+        one_liner: String::new(),
+        goal: String::new(),
+    }.is_ephemeral());
+    assert!(!EventPayload::TranscriptAppended {
+        message: TranscriptMessage::new("x".into(), "y".into()),
+    }.is_ephemeral());
+}
+```
+
+In `crates/barnstormer-core/src/state.rs` tests, add:
+
+```rust
+#[test]
+fn apply_streaming_delta_is_noop() {
+    let mut state = SpecState::new();
+    let spec_id = make_spec_id();
+    let before = state.clone();
+    state.apply(&make_event(
+        spec_id,
+        1,
+        EventPayload::StreamingDelta {
+            agent_id: "manager-1".to_string(),
+            text: "Hello".to_string(),
+        },
+    ));
+    // State should be unchanged except for last_event_id
+    assert_eq!(state.core, before.core);
+    assert_eq!(state.cards.len(), before.cards.len());
+    assert_eq!(state.transcript.len(), before.transcript.len());
+}
+```
+
+In `crates/barnstormer-core/src/actor.rs` tests, add:
+
+```rust
+#[tokio::test]
+async fn actor_broadcasts_streaming_delta() {
+    let spec_id = Ulid::new();
+    let handle = spawn(spec_id, SpecState::new());
+    let mut rx = handle.subscribe();
+
+    let events = handle
+        .send_command(Command::StreamDelta {
+            agent_id: "manager-1".to_string(),
+            text: "Hi".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    match &events[0].payload {
+        EventPayload::StreamingDelta { agent_id, text } => {
+            assert_eq!(agent_id, "manager-1");
+            assert_eq!(text, "Hi");
+        }
+        _ => panic!("expected StreamingDelta"),
+    }
+
+    let broadcast = rx.recv().await.unwrap();
+    match &broadcast.payload {
+        EventPayload::StreamingDelta { .. } => {}
+        _ => panic!("expected StreamingDelta broadcast"),
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: FAIL — `StreamingDelta`, `StreamingToolActivity`, `StreamDelta`, `StreamToolActivity` don't exist yet.
+
+**Step 3: Implement the types and handlers**
+
+In `crates/barnstormer-core/src/event.rs`, add two new variants to `EventPayload` (after `CanvasUpdated`):
+
+```rust
+StreamingDelta {
+    agent_id: String,
+    text: String,
+},
+StreamingToolActivity {
+    agent_id: String,
+    activity: String,
+},
+```
+
+Add an `impl EventPayload` block (or extend existing one) with:
+
+```rust
+impl EventPayload {
+    /// Returns true for events that should not be persisted to the event log.
+    /// Streaming events are broadcast-only — they carry ephemeral LLM state
+    /// that has no meaning during replay.
+    pub fn is_ephemeral(&self) -> bool {
+        matches!(
+            self,
+            EventPayload::StreamingDelta { .. } | EventPayload::StreamingToolActivity { .. }
+        )
+    }
+}
+```
+
+In `crates/barnstormer-core/src/command.rs`, add two new variants to `Command` (after `Undo`):
+
+```rust
+StreamDelta {
+    agent_id: String,
+    text: String,
+},
+StreamToolActivity {
+    agent_id: String,
+    activity: String,
+},
+```
+
+In `crates/barnstormer-core/src/actor.rs`, add two arms to `command_to_events` (before the closing `};` of the match):
+
+```rust
+Command::StreamDelta { agent_id, text } => {
+    vec![EventPayload::StreamingDelta { agent_id, text }]
+}
+
+Command::StreamToolActivity { agent_id, activity } => {
+    vec![EventPayload::StreamingToolActivity { agent_id, activity }]
+}
+```
+
+In `crates/barnstormer-core/src/state.rs`, add two no-op arms to the `apply` method's match (before the closing `}` of the match):
+
+```rust
+EventPayload::StreamingDelta { .. } => {
+    // Ephemeral — no state mutation
+}
+EventPayload::StreamingToolActivity { .. } => {
+    // Ephemeral — no state mutation
+}
+```
+
+Also add the same two arms to `apply_without_undo` if it has an exhaustive match.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: all tests pass.
+
+**Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+**Step 6: Commit**
+
+```bash
+git add crates/barnstormer-core/src/command.rs crates/barnstormer-core/src/event.rs crates/barnstormer-core/src/actor.rs crates/barnstormer-core/src/state.rs
+git commit -m "feat: add ephemeral StreamingDelta and StreamingToolActivity events"
+```
+
+---
+
+### Task 2: Wire SSE event names and persister skip
+
+Map the new event variants to SSE event names and make the persister skip ephemeral events.
+
+**Files:**
+- Modify: `crates/barnstormer-server/src/api/stream.rs`
+- Modify: `crates/barnstormer-server/src/web/mod.rs` (persister, around line 2671)
+
+**Step 1: Write failing test**
+
+In `crates/barnstormer-server/src/api/stream.rs`, add to `mod tests`:
+
+```rust
+#[test]
+fn event_type_names_streaming() {
+    use barnstormer_core::EventPayload;
+
+    assert_eq!(
+        event_type_name(&EventPayload::StreamingDelta {
+            agent_id: String::new(),
+            text: String::new(),
+        }),
+        "streaming_delta"
+    );
+    assert_eq!(
+        event_type_name(&EventPayload::StreamingToolActivity {
+            agent_id: String::new(),
+            activity: String::new(),
+        }),
+        "streaming_tool_activity"
+    );
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p barnstormer-server 2>&1 | tail -20`
+Expected: FAIL — non-exhaustive match in `event_type_name`.
+
+**Step 3: Implement**
+
+In `crates/barnstormer-server/src/api/stream.rs`, add two arms to `event_type_name`:
+
+```rust
+barnstormer_core::EventPayload::StreamingDelta { .. } => "streaming_delta",
+barnstormer_core::EventPayload::StreamingToolActivity { .. } => "streaming_tool_activity",
+```
+
+In `crates/barnstormer-server/src/web/mod.rs`, in the `spawn_event_persister` function, change the event receive loop (around line 2671-2680) from:
+
+```rust
+Ok(event) => {
+    if let Err(e) = log.append(&event) {
+```
+
+to:
+
+```rust
+Ok(event) => {
+    if event.payload.is_ephemeral() {
+        continue;
+    }
+    if let Err(e) = log.append(&event) {
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/barnstormer-server/src/api/stream.rs crates/barnstormer-server/src/web/mod.rs
+git commit -m "feat: map streaming events to SSE, skip ephemeral events in persister"
+```
+
+---
+
+### Task 3: Implement StreamingHook in barnstormer-agent
+
+Create the hook that bridges mux streaming callbacks to barnstormer commands.
+
+**Files:**
+- Create: `crates/barnstormer-agent/src/streaming_hook.rs`
+- Modify: `crates/barnstormer-agent/src/lib.rs`
+
+**Step 1: Write failing test**
+
+Create `crates/barnstormer-agent/src/streaming_hook.rs` with tests that verify the hook sends the right commands:
+
+```rust
+// ABOUTME: Mux Hook implementation that forwards LLM streaming events to the spec actor.
+// ABOUTME: Bridges StreamDelta and tool-use callbacks into ephemeral broadcast events.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use barnstormer_core::{Command, SpecActorHandle};
+use mux::hook::{Hook, HookAction, HookEvent};
+
+/// Forwards mux streaming events to the spec actor as ephemeral commands.
+/// For the manager agent, forwards text deltas (token-by-token streaming).
+/// For all agents, forwards tool activity and iteration status.
+pub struct StreamingHook {
+    actor: Arc<SpecActorHandle>,
+    agent_id: String,
+    is_manager: bool,
+}
+
+impl StreamingHook {
+    pub fn new(actor: Arc<SpecActorHandle>, agent_id: String, is_manager: bool) -> Self {
+        Self {
+            actor,
+            agent_id,
+            is_manager,
+        }
+    }
+}
+
+#[async_trait]
+impl Hook for StreamingHook {
+    fn accepts(&self, event: &HookEvent) -> bool {
+        matches!(
+            event,
+            HookEvent::StreamDelta { .. }
+                | HookEvent::PostToolUse { .. }
+                | HookEvent::Iteration { .. }
+        )
+    }
+
+    async fn on_event(&self, event: &HookEvent) -> Result<HookAction, anyhow::Error> {
+        match event {
+            HookEvent::StreamDelta { text, .. } if self.is_manager => {
+                let _ = self
+                    .actor
+                    .send_command(Command::StreamDelta {
+                        agent_id: self.agent_id.clone(),
+                        text: text.clone(),
+                    })
+                    .await;
+            }
+            HookEvent::PostToolUse {
+                tool_name, input, ..
+            } => {
+                // Build a short activity description from the tool name and key input fields
+                let subject = input
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let activity = if subject.is_empty() {
+                    format!("{}: {}", self.agent_id, tool_name)
+                } else {
+                    format!("{}: {} '{}'", self.agent_id, tool_name, subject)
+                };
+                let _ = self
+                    .actor
+                    .send_command(Command::StreamToolActivity {
+                        agent_id: self.agent_id.clone(),
+                        activity,
+                    })
+                    .await;
+            }
+            HookEvent::Iteration { .. } => {
+                let _ = self
+                    .actor
+                    .send_command(Command::StreamToolActivity {
+                        agent_id: self.agent_id.clone(),
+                        activity: format!("{}: thinking...", self.agent_id),
+                    })
+                    .await;
+            }
+            _ => {}
+        }
+        Ok(HookAction::Continue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use barnstormer_core::{SpecState, spawn};
+    use ulid::Ulid;
+
+    #[tokio::test]
+    async fn hook_sends_streaming_delta_for_manager() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+        let mut rx = handle.subscribe();
+
+        let hook = StreamingHook::new(
+            Arc::new(handle.clone()),
+            "manager-1".to_string(),
+            true,
+        );
+
+        let event = HookEvent::StreamDelta {
+            agent_id: "ignored".to_string(),
+            text: "Hello".to_string(),
+        };
+        assert!(hook.accepts(&event));
+        hook.on_event(&event).await.unwrap();
+
+        let broadcast = rx.recv().await.unwrap();
+        match &broadcast.payload {
+            barnstormer_core::EventPayload::StreamingDelta { agent_id, text } => {
+                assert_eq!(agent_id, "manager-1");
+                assert_eq!(text, "Hello");
+            }
+            _ => panic!("expected StreamingDelta, got {:?}", broadcast.payload),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_ignores_streaming_delta_for_non_manager() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+        let mut rx = handle.subscribe();
+
+        let hook = StreamingHook::new(
+            Arc::new(handle.clone()),
+            "brainstormer-1".to_string(),
+            false,
+        );
+
+        let event = HookEvent::StreamDelta {
+            agent_id: "ignored".to_string(),
+            text: "Hello".to_string(),
+        };
+        hook.on_event(&event).await.unwrap();
+
+        // Should NOT have received anything
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            rx.recv(),
+        )
+        .await;
+        assert!(result.is_err(), "should timeout — no event broadcast");
+    }
+
+    #[tokio::test]
+    async fn hook_sends_tool_activity_for_any_agent() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+        let mut rx = handle.subscribe();
+
+        let hook = StreamingHook::new(
+            Arc::new(handle.clone()),
+            "brainstormer-1".to_string(),
+            false,
+        );
+
+        let event = HookEvent::PostToolUse {
+            tool_name: "create_card".to_string(),
+            tool_use_id: "tu-1".to_string(),
+            input: serde_json::json!({ "title": "Auth Flow" }),
+            result: mux::tool::ToolResult {
+                content: vec![],
+                is_error: false,
+            },
+        };
+        assert!(hook.accepts(&event));
+        hook.on_event(&event).await.unwrap();
+
+        let broadcast = rx.recv().await.unwrap();
+        match &broadcast.payload {
+            barnstormer_core::EventPayload::StreamingToolActivity { activity, .. } => {
+                assert!(activity.contains("create_card"));
+                assert!(activity.contains("Auth Flow"));
+            }
+            _ => panic!("expected StreamingToolActivity"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_sends_thinking_on_iteration() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+        let mut rx = handle.subscribe();
+
+        let hook = StreamingHook::new(
+            Arc::new(handle.clone()),
+            "planner-1".to_string(),
+            false,
+        );
+
+        let event = HookEvent::Iteration {
+            agent_id: "ignored".to_string(),
+            iteration: 1,
+        };
+        assert!(hook.accepts(&event));
+        hook.on_event(&event).await.unwrap();
+
+        let broadcast = rx.recv().await.unwrap();
+        match &broadcast.payload {
+            barnstormer_core::EventPayload::StreamingToolActivity { activity, .. } => {
+                assert!(activity.contains("thinking"));
+            }
+            _ => panic!("expected StreamingToolActivity"),
+        }
+    }
+
+    #[test]
+    fn hook_rejects_irrelevant_events() {
+        let spec_id = Ulid::new();
+        let handle = spawn(spec_id, SpecState::new());
+
+        let hook = StreamingHook::new(
+            Arc::new(handle),
+            "manager-1".to_string(),
+            true,
+        );
+
+        let event = HookEvent::AgentStart {
+            agent_id: "x".to_string(),
+            task: "y".to_string(),
+        };
+        assert!(!hook.accepts(&event));
+    }
+}
+```
+
+**Step 2: Register the module**
+
+In `crates/barnstormer-agent/src/lib.rs`, add:
+
+```rust
+pub mod streaming_hook;
+```
+
+**Step 3: Run tests to verify they pass**
+
+Run: `cargo test -p barnstormer-agent 2>&1 | tail -20`
+Expected: all tests pass.
+
+**Step 4: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+**Step 5: Commit**
+
+```bash
+git add crates/barnstormer-agent/src/streaming_hook.rs crates/barnstormer-agent/src/lib.rs
+git commit -m "feat: add StreamingHook bridging mux callbacks to spec actor commands"
+```
+
+---
+
+### Task 4: Wire hooks into swarm agent creation
+
+Enable streaming on the manager's `AgentDefinition` and attach `StreamingHook` to all SubAgent instances.
+
+**Files:**
+- Modify: `crates/barnstormer-agent/src/swarm.rs` (around lines 388-401)
+
+**Step 1: Add imports at the top of swarm.rs**
+
+Add to the imports section:
+
+```rust
+use crate::streaming_hook::StreamingHook;
+use mux::hook::HookRegistry;
+```
+
+**Step 2: Modify the `run_agent_step` function**
+
+In the `run_agent_step` function (around line 388), after building the `AgentDefinition`:
+
+```rust
+let definition = AgentDefinition::new(
+    runner.role.label(),
+    full_system_prompt(&runner.role, &runner.agent_id, phase),
+)
+.model(model)
+.max_iterations(10);
+```
+
+Change to conditionally enable streaming for the manager:
+
+```rust
+let is_manager = runner.role == AgentRole::Manager;
+let mut definition = AgentDefinition::new(
+    runner.role.label(),
+    full_system_prompt(&runner.role, &runner.agent_id, phase),
+)
+.model(model)
+.max_iterations(10);
+
+if is_manager {
+    definition = definition.streaming(true);
+}
+```
+
+After creating the SubAgent (line 397-401), add hook wiring:
+
+```rust
+let mut sub_agent = SubAgent::new(
+    definition,
+    Arc::clone(client),
+    registry,
+);
+
+// Attach streaming hook for real-time event forwarding
+let hook_registry = Arc::new(HookRegistry::new());
+let hook = StreamingHook::new(
+    Arc::clone(actor),
+    runner.agent_id.clone(),
+    is_manager,
+);
+// Use block_on-safe approach: register is async because HookRegistry uses RwLock
+{
+    hook_registry.register(hook).await;
+}
+sub_agent = sub_agent.with_hooks(hook_registry);
+```
+
+**Step 3: Add AgentRole import if not already present**
+
+Check imports at the top of `swarm.rs`. The `AgentRole` type should already be available via `use crate::context::AgentRole;` or similar. If not, add it.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: all tests pass.
+
+**Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+**Step 6: Commit**
+
+```bash
+git add crates/barnstormer-agent/src/swarm.rs
+git commit -m "feat: wire StreamingHook into SubAgent creation, enable manager streaming"
+```
+
+---
+
+### Task 5: Add streaming UI elements to chat transcript template
+
+Add the streaming message placeholder, activity status line, and JavaScript SSE listeners.
+
+**Files:**
+- Modify: `templates/partials/chat_transcript.html`
+- Modify: `static/style.css`
+
+**Step 1: Add streaming DOM elements**
+
+In `templates/partials/chat_transcript.html`, after the throbber div (line 44, after the closing `</div>` of the throbber), add:
+
+```html
+<div id="{{ container_id }}-streaming" class="chat-streaming-msg" style="display:none;">
+    <div class="chat-message">
+        <div class="chat-message-header">
+            <div class="chat-avatar avatar-manager">O</div>
+            <span class="chat-sender">Orchestrator</span>
+        </div>
+        <div class="chat-body" id="{{ container_id }}-streaming-body"></div>
+    </div>
+</div>
+<div id="{{ container_id }}-activity" class="chat-activity-status" style="display:none;">
+    <span class="status-dot dot-agent"></span>
+    <span id="{{ container_id }}-activity-text"></span>
+</div>
+```
+
+**Step 2: Add JavaScript SSE listeners**
+
+In the `<script>` block at the bottom of `chat_transcript.html`, inside the `if (compositor)` block (after the existing `agent_step_finished` listener, around line 182), add:
+
+```javascript
+var streamingId = '{{ container_id }}-streaming';
+var streamingBodyId = '{{ container_id }}-streaming-body';
+var activityId = '{{ container_id }}-activity';
+var activityTextId = '{{ container_id }}-activity-text';
+
+compositor.addEventListener('sse:streaming_delta', function(evt) {
+    var data = {};
+    try { data = JSON.parse(evt.detail.data || '{}'); } catch(e) {}
+    if (!data.payload || data.payload.type !== 'StreamingDelta') return;
+    var text = data.payload.text || '';
+
+    // Hide throbber, show streaming message
+    var th = document.getElementById(throbberId);
+    if (th) th.style.display = 'none';
+    var act = document.getElementById(activityId);
+    if (act) act.style.display = 'none';
+
+    var sm = document.getElementById(streamingId);
+    var sb = document.getElementById(streamingBodyId);
+    if (sm && sb) {
+        sm.style.display = '';
+        sb.textContent += text;
+    }
+
+    // Auto-scroll
+    var f = document.getElementById(feedId);
+    if (f) f.scrollTop = f.scrollHeight;
+});
+
+compositor.addEventListener('sse:streaming_tool_activity', function(evt) {
+    var data = {};
+    try { data = JSON.parse(evt.detail.data || '{}'); } catch(e) {}
+    if (!data.payload || data.payload.type !== 'StreamingToolActivity') return;
+    var activity = data.payload.activity || '';
+
+    var act = document.getElementById(activityId);
+    var actText = document.getElementById(activityTextId);
+    if (act && actText) {
+        act.style.display = '';
+        actText.textContent = activity;
+    }
+
+    // Auto-scroll
+    var f = document.getElementById(feedId);
+    if (f) f.scrollTop = f.scrollHeight;
+});
+
+// When transcript_appended arrives (HTMX will re-render), clean up streaming state.
+// The HTMX swap replaces the entire container including our streaming div,
+// so this is handled automatically. But we also listen for the raw SSE event
+// to hide the streaming div slightly before the swap for a cleaner transition.
+compositor.addEventListener('sse:transcript_appended', function() {
+    var sm = document.getElementById(streamingId);
+    if (sm) sm.style.display = 'none';
+});
+
+// Hide activity on agent_step_finished (already have a listener that hides throbber)
+// Extend the existing listener or add a new one:
+compositor.addEventListener('sse:agent_step_finished', function() {
+    var act = document.getElementById(activityId);
+    if (act) act.style.display = 'none';
+});
+```
+
+Note: there's already an `agent_step_finished` listener that hides the throbber. The second listener here adds activity-hiding behavior. Alternatively, merge them into one listener — but two listeners on the same event is fine and keeps concerns separate.
+
+**Step 3: Add CSS styling**
+
+Append to `static/style.css`:
+
+```css
+/* Streaming message — raw text while tokens arrive */
+.chat-streaming-msg {
+    padding: 8px 20px;
+}
+.chat-streaming-msg .chat-body {
+    white-space: pre-wrap;
+    font-family: inherit;
+    min-height: 20px;
+}
+
+/* Worker activity status line — "tail -n 1" of agent activity */
+.chat-activity-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 20px;
+    font-size: 12px;
+    color: var(--text-muted);
+    opacity: 0.8;
+}
+.chat-activity-status .status-dot {
+    flex-shrink: 0;
+}
+```
+
+**Step 4: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds (Askama templates are compiled at build time).
+
+**Step 5: Commit**
+
+```bash
+git add templates/partials/chat_transcript.html static/style.css
+git commit -m "feat: add streaming message placeholder and worker activity status line"
+```
+
+---
+
+### Task 6: Update command round-trip tests
+
+The existing command round-trip test in `command.rs` tests all variants. Add the new ones.
+
+**Files:**
+- Modify: `crates/barnstormer-core/src/command.rs`
+
+**Step 1: Add to existing round-trip test**
+
+In `crates/barnstormer-core/src/command.rs`, in the `command_serializes_round_trip` test, add to the `commands` vec:
+
+```rust
+Command::StreamDelta {
+    agent_id: "manager-1".to_string(),
+    text: "token".to_string(),
+},
+Command::StreamToolActivity {
+    agent_id: "brainstormer-1".to_string(),
+    activity: "creating card".to_string(),
+},
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p barnstormer-core 2>&1 | tail -20`
+Expected: all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add crates/barnstormer-core/src/command.rs
+git commit -m "test: add streaming command round-trip tests"
+```
+
+---
+
+### Task 7: Full test suite and clippy
+
+**Step 1: Run all tests**
+
+Run: `cargo test --all 2>&1 | tail -30`
+Expected: all tests pass.
+
+**Step 2: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+**Step 3: Fix any issues, commit if needed**
+
+---
+
+## Task Order & Dependencies
+
+```
+Task 1 (core event types)  ── must be first, all others depend on it
+Task 2 (SSE + persister)   ── depends on Task 1
+Task 3 (StreamingHook)     ── depends on Task 1
+Task 4 (swarm wiring)      ── depends on Tasks 1 + 3
+Task 5 (UI templates)      ── depends on Task 2 (SSE event names)
+Task 6 (test cleanup)      ── depends on Task 1
+Task 7 (full test suite)   ── must be last
+```
+
+Tasks 2, 3, and 5 can run in parallel after Task 1 is done (but with subagent-driven development they run sequentially).

--- a/docs/plans/2026-04-16-ux-fixes-implementation.md
+++ b/docs/plans/2026-04-16-ux-fixes-implementation.md
@@ -1,0 +1,640 @@
+# UX Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix 14 UX issues found during hands-on testing (all items from `docs/plans/2026-04-16-ux-issues-from-testing.md` except #13 streaming, #5 context loss, #9 backend-confirmed, #11 already fixed).
+
+**Architecture:** All changes are in the `feature/phase-wayfinding` branch, stacked on top of existing commits. Fixes are grouped by dependency: quick HTML/CSS wins first, then template logic changes, then SSE infrastructure improvements.
+
+**Tech Stack:** Rust (Axum, Askama templates), HTML/CSS, JavaScript (HTMX, SSE), no new dependencies.
+
+---
+
+### Task 1: Quick wins — focus "Something else", textarea height, lane tooltips (#3, #4, #14)
+
+Three independent micro-fixes in templates and CSS.
+
+**Files:**
+- Modify: `templates/partials/chat_transcript.html:58,61,80,83,100`
+- Modify: `templates/partials/board.html:4-6`
+- Modify: `static/style.css`
+
+**Step 1: Add focus() call to "Something else" onclick handlers**
+
+In `templates/partials/chat_transcript.html`, the Boolean question "Something else" button (line 58) has an onclick handler. Append `f.querySelector('.chat-else-expand textarea').focus();` to the end of the onclick string.
+
+There are two instances to fix:
+1. Boolean question (line 58): change the onclick to:
+```
+onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();"
+```
+2. MultipleChoice question (line 80): same change.
+
+**Step 2: Standardize textarea rows to 1**
+
+In `templates/partials/chat_transcript.html`, change all `rows="2"` on the "Something else" textareas to `rows="1"`:
+- Line 61: `<textarea placeholder="Describe what you mean..." rows="1" ...>`
+- Line 83: same
+- Line 100 (Freeform question): change `rows="2"` to `rows="1"`
+
+**Step 3: Add tooltips to lane headers**
+
+In `templates/partials/board.html`, replace line 5:
+```html
+<h3>{{ lane.name }}</h3>
+```
+with:
+```html
+<h3 title="{% if lane.name == "Ideas" %}Raw ideas from brainstorming — unstructured thoughts and suggestions.{% else if lane.name == "Plan" %}Items being refined into actionable tasks for the spec.{% else if lane.name == "Spec" %}Finalized spec items that define the implementation.{% else %}{{ lane.name }}{% endif %}">{{ lane.name }}</h3>
+```
+
+**Step 4: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds (templates are compiled at build time in Askama).
+
+**Step 5: Commit**
+
+```bash
+git add templates/partials/chat_transcript.html templates/partials/board.html
+git commit -m "fix: focus 'something else' textarea, standardize rows, add lane tooltips (#3, #4, #14)"
+```
+
+---
+
+### Task 2: Thinking throbber — show activity during agent reasoning (#2, #6, #12)
+
+When agents are working (between `agent_step_started` and `agent_step_finished`), show an animated thinking indicator in the chat transcript.
+
+**Files:**
+- Modify: `templates/partials/chat_transcript.html`
+- Modify: `static/style.css`
+
+**Step 1: Add throbber element to chat transcript**
+
+At the bottom of the chat messages div (after the `{% endfor %}` on line 30, before the `{% if transcript.is_empty() %}` block on line 31), insert a hidden throbber element:
+
+```html
+<div id="{{ container_id }}-throbber" class="chat-throbber" style="display:none;">
+    <div class="chat-message">
+        <div class="chat-message-header">
+            <div class="chat-avatar avatar-manager">T</div>
+            <span class="chat-sender">Orchestrator</span>
+        </div>
+        <div class="chat-body">
+            <span class="thinking-dots"><span></span><span></span><span></span></span>
+        </div>
+    </div>
+</div>
+```
+
+**Step 2: Add throbber toggle JavaScript**
+
+In the `<script>` block at the bottom of `chat_transcript.html` (inside the IIFE, after the scroll position logic), add SSE listeners that toggle the throbber:
+
+```javascript
+var compositor = document.querySelector('.spec-compositor');
+var throbberId = '{{ container_id }}-throbber';
+if (compositor) {
+    compositor.addEventListener('sse:agent_step_started', function() {
+        var th = document.getElementById(throbberId);
+        if (th) { th.style.display = ''; }
+        var f = document.getElementById(feedId);
+        if (f) { f.scrollTop = f.scrollHeight; }
+    });
+    compositor.addEventListener('sse:agent_step_finished', function() {
+        var th = document.getElementById(throbberId);
+        if (th) { th.style.display = 'none'; }
+    });
+}
+```
+
+**Step 3: Add throbber CSS animation**
+
+Append to `static/style.css`:
+
+```css
+/* Thinking throbber — three bouncing dots */
+.chat-throbber {
+    padding: 8px 20px;
+}
+.thinking-dots {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+    height: 20px;
+}
+.thinking-dots span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    animation: throbberBounce 1.4s ease-in-out infinite;
+}
+.thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+.thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes throbberBounce {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+}
+```
+
+**Step 4: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds.
+
+**Step 5: Commit**
+
+```bash
+git add templates/partials/chat_transcript.html static/style.css
+git commit -m "feat: add thinking throbber during agent reasoning steps (#2, #6, #12)"
+```
+
+---
+
+### Task 3: Multi-select checkboxes for allow_multi questions (#1)
+
+When `allow_multi` is true on a MultipleChoice question, render checkboxes with a Submit button instead of individual submit buttons.
+
+**Files:**
+- Modify: `templates/partials/chat_transcript.html:69-89`
+
+**Step 1: Replace the MultipleChoice form with conditional rendering**
+
+Replace the entire MultipleChoice block (lines 69-89) with:
+
+```html
+{% when QuestionData::MultipleChoice { question_id, question, choices, allow_multi } %}
+<div class="chat-question-body">{{ question|safe }}</div>
+<form hx-post="/web/specs/{{ spec_id }}/answer"
+      hx-target="#{{ container_id }}"
+      hx-swap="outerHTML"
+      autocomplete="off"
+      class="chat-question-options">
+    <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
+    {% if allow_multi %}
+    {% for choice in choices %}
+    <label class="chat-option-checkbox">
+        <input type="checkbox" name="answer" value="{{ choice }}">
+        <span>{{ choice }}</span>
+    </label>
+    {% endfor %}
+    <button type="submit" class="chat-option-btn chat-option-submit" onclick="var f=this.closest('form'); var checked=f.querySelectorAll('input[name=answer]:checked'); if(checked.length===0){event.preventDefault(); return;} var vals=[]; checked.forEach(function(c){vals.push(c.value);}); var h=document.createElement('input'); h.type='hidden'; h.name='answer'; h.value=vals.join(', '); f.appendChild(h); checked.forEach(function(c){c.disabled=true;});">Submit</button>
+    {% else %}
+    {% for choice in choices %}
+    <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
+    {% endfor %}
+    {% endif %}
+    <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn, .chat-option-checkbox').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
+    <div class="chat-else-expand" style="display:none;">
+        <div class="chat-input-row">
+            <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore required></textarea>
+            <button type="submit" class="btn btn-send" title="Send">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+            </button>
+        </div>
+    </div>
+</form>
+```
+
+**Step 2: Add checkbox styling to CSS**
+
+Append to `static/style.css`:
+
+```css
+/* Multi-select checkboxes in question cards */
+.chat-option-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    border-radius: var(--radius-xl);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 12px 16px;
+    font-size: 14px;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.chat-option-checkbox:hover {
+    border-color: var(--text-muted);
+}
+.chat-option-checkbox:has(input:checked) {
+    border-color: var(--text-primary);
+    background: var(--bg-secondary);
+}
+.chat-option-checkbox input[type="checkbox"] {
+    accent-color: var(--text-primary);
+    width: 16px;
+    height: 16px;
+}
+.chat-option-submit {
+    background: var(--text-primary);
+    color: var(--bg-card);
+    text-align: center;
+    font-weight: 600;
+}
+.chat-option-submit:hover {
+    opacity: 0.85;
+}
+```
+
+**Step 3: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add templates/partials/chat_transcript.html static/style.css
+git commit -m "feat: render checkboxes for multi-select questions (#1)"
+```
+
+---
+
+### Task 4: Fix chat width after board toggle in brainstorming (#7)
+
+When toggling from "View Board" back to "Back to Chat" in brainstorming mode, the chat renders full-viewport instead of the constrained center column.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html:56-70`
+
+**Step 1: Fix the toggle script to restore canvas overflow style**
+
+The issue is that when the board loads, it replaces the chat panel inside `#canvas`. When "Back to Chat" fetches the chat panel again via HTMX, the `.canvas` element still has board-related sizing. The fix is to ensure the canvas styling resets properly.
+
+In `templates/partials/spec_view.html`, replace the brainstorming toggle script (lines 55-101) with a version that also resets canvas overflow:
+
+After `btnChat.addEventListener('click', function() {` (line 66), the HTMX fetch already handles content replacement. The real issue is the `.canvas` selector in CSS needs `overflow-y: hidden` for brainstorming (since the chat panel manages its own scroll) but the board needs `overflow-y: auto`. Add an explicit class toggle:
+
+```javascript
+btnBoard.addEventListener('click', function() {
+    btnBoard.style.display = 'none';
+    btnChat.style.display = '';
+    document.getElementById('canvas').classList.add('canvas-board');
+});
+```
+```javascript
+btnChat.addEventListener('click', function() {
+    btnChat.style.display = 'none';
+    btnBoard.style.display = '';
+    document.getElementById('canvas').classList.remove('canvas-board');
+});
+```
+
+**Step 2: Add CSS for canvas-board state**
+
+In `static/style.css`, after the existing `.canvas` rule, add:
+
+```css
+.canvas.canvas-board {
+    overflow-y: auto;
+    padding: var(--spacing-lg);
+}
+```
+
+And update the brainstorming canvas rule to be explicit:
+
+```css
+[data-view="brainstorming"] .spec-body > .canvas {
+    flex: 1;
+    min-width: 300px;
+    overflow-y: hidden;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+[data-view="brainstorming"] .spec-body > .canvas.canvas-board {
+    overflow-y: auto;
+    padding: var(--spacing-lg);
+    display: block;
+}
+```
+
+**Step 3: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add templates/partials/spec_view.html static/style.css
+git commit -m "fix: restore chat column width after board toggle in brainstorming (#7)"
+```
+
+---
+
+### Task 5: Phase transition rendering fallback (#8)
+
+The `sse:phase_transitioned` event handler does `htmx.ajax()` to reload the workspace, but if the SSE connection drops, the UI never updates. Add a polling fallback that checks current phase periodically and reloads if it changed.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html` (all three phase blocks)
+- Modify: `crates/barnstormer-server/src/web/mod.rs` (add phase-check endpoint)
+
+**Step 1: Add a lightweight phase-check API endpoint**
+
+In `crates/barnstormer-server/src/web/mod.rs`, add a new handler near the other spec endpoints:
+
+```rust
+/// Returns the current phase as plain text — used by the client-side
+/// polling fallback when SSE might be disconnected.
+pub async fn phase_check(
+    State(state): State<SharedState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let spec_id = match parse_spec_id(&id) {
+        Ok(id) => id,
+        Err(resp) => return *resp,
+    };
+    let actors = state.actors.read().await;
+    let handle = match actors.get(&spec_id) {
+        Some(h) => h,
+        None => {
+            return (StatusCode::NOT_FOUND, "not_found").into_response();
+        }
+    };
+    let spec_state = handle.read_state().await;
+    let phase_str = match spec_state.phase {
+        crate::state::SpecPhase::Brainstorming => "brainstorming",
+        crate::state::SpecPhase::Refining => "refining",
+        crate::state::SpecPhase::Complete => "complete",
+    };
+    phase_str.into_response()
+}
+```
+
+**Step 2: Register the route**
+
+Find the router setup (search for `.route("/web/specs/:id/phase"`) and add a GET route near it:
+
+```rust
+.route("/web/specs/:id/phase-check", get(phase_check))
+```
+
+**Step 3: Add phase polling fallback to all three phase blocks**
+
+In each of the three `<script>` blocks in `spec_view.html`, after the `sse:phase_transitioned` listener, add:
+
+```javascript
+// Polling fallback: if SSE drops, check phase every 15 seconds
+var currentPhase = '{{ phase }}';
+setInterval(function() {
+    fetch('/web/specs/{{ spec_id }}/phase-check')
+        .then(function(r) { return r.text(); })
+        .then(function(serverPhase) {
+            if (serverPhase !== currentPhase) {
+                htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+            }
+        })
+        .catch(function() {}); // silently ignore network errors
+}, 15000);
+```
+
+**Step 4: Build and test**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds.
+
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/barnstormer-server/src/web/mod.rs templates/partials/spec_view.html
+git commit -m "feat: add phase polling fallback for SSE disconnection (#8)"
+```
+
+---
+
+### Task 6: Sidebar refresh on spec creation (#10)
+
+The sidebar spec list loads once and never updates. Add an SSE listener so it refreshes when a spec is created.
+
+**Files:**
+- Modify: `templates/partials/spec_list.html`
+- Modify: `templates/base.html` (add SSE connection for sidebar)
+
+**Step 1: Add HTMX polling trigger to spec list**
+
+The sidebar needs to know when specs change, but it sits outside the per-spec SSE connection. The simplest approach is a periodic poll (every 30 seconds) plus a manual refresh trigger.
+
+Replace the `spec_list.html` content wrapper to add a refresh trigger:
+
+In `templates/base.html`, find the nav block. The spec list is loaded inside the nav rail. We need to add `hx-trigger="load, every 30s"` to the spec list container.
+
+First, check how the nav is rendered. The spec list div likely already has `hx-get="/web/specs" hx-trigger="load"`. Change its trigger to:
+
+```html
+<div class="spec-list" id="spec-list"
+     hx-get="/web/specs"
+     hx-trigger="load, every 30s"
+     hx-swap="innerHTML">
+</div>
+```
+
+This is in the page template that includes the nav, not `base.html` itself. Search for where the spec list is rendered.
+
+**Step 2: Find and modify the spec list container**
+
+Look for the template that renders the nav rail content with the spec list loading. It should be in the main page template (likely `templates/index.html` or `templates/home.html`). Modify its `hx-trigger` to include `every 30s`.
+
+**Step 3: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add templates/
+git commit -m "feat: auto-refresh sidebar spec list every 30s (#10)"
+```
+
+---
+
+### Task 7: Improve manager error messages (#15)
+
+The "[manager] encountered an issue and will retry" message appears repeatedly with no context. Improve the error message and collapse repeated identical errors.
+
+**Files:**
+- Modify: `crates/barnstormer-agent/src/swarm.rs` (find the retry message)
+- Modify: `templates/partials/chat_transcript.html` (collapse repeated status lines)
+
+**Step 1: Find the retry error message in the agent crate**
+
+Search for "encountered an issue" or "will retry" in the agent crate to find where this message is generated. Update it to include more context about what failed (e.g., "LLM call failed: rate limited" or "response parsing error").
+
+The fix should change the generic message to include the error kind:
+
+```rust
+// Instead of:
+// "[manager] encountered an issue and will retry on the next cycle"
+// Use:
+format!("[{}] encountered an issue ({}). Will retry on the next cycle.", agent_id, error_summary)
+```
+
+Where `error_summary` is a short description of the error (first 100 chars of the error message, sanitized).
+
+**Step 2: Collapse consecutive identical status lines in the template**
+
+In `templates/partials/chat_transcript.html`, the status line rendering loop (lines 12-17) shows every step event. Add a deduplication check: if the current status line content matches the previous one, skip rendering it and instead show a "repeated N times" indicator.
+
+This requires passing a `repeat_count` field on `TranscriptEntry` from the server side. In `crates/barnstormer-server/src/web/mod.rs`, in the transcript processing logic, before rendering, collapse consecutive identical step messages:
+
+```rust
+// After building transcript entries, collapse consecutive identical steps
+let mut collapsed: Vec<TranscriptEntry> = Vec::new();
+for entry in entries {
+    if entry.is_step {
+        if let Some(last) = collapsed.last_mut() {
+            if last.is_step && last.content == entry.content {
+                last.repeat_count += 1;
+                continue;
+            }
+        }
+    }
+    collapsed.push(entry);
+}
+```
+
+Add `repeat_count: u32` to `TranscriptEntry` struct (default 1).
+
+In the template, show the repeat count:
+```html
+{% if entry.repeat_count > 1 %}
+<span class="chat-status-repeat">(×{{ entry.repeat_count }})</span>
+{% endif %}
+```
+
+**Step 3: Add CSS for repeat count**
+
+```css
+.chat-status-repeat {
+    font-size: 10px;
+    color: var(--text-muted);
+    opacity: 0.6;
+    white-space: nowrap;
+}
+```
+
+**Step 4: Build and test**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Run: `cargo test --all 2>&1 | tail -20`
+Expected: compilation and tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/barnstormer-agent/src/swarm.rs crates/barnstormer-server/src/web/mod.rs templates/partials/chat_transcript.html static/style.css
+git commit -m "fix: add error context to manager retry messages, collapse repeated errors (#15)"
+```
+
+---
+
+### Task 8: Fix Export to Disk button (#16)
+
+The "Export to Disk" button appears to do nothing. The handler POSTs to `/web/specs/{id}/regenerate` and targets `.regen-status`, a tiny `<span>`. The response may be working but invisible.
+
+**Files:**
+- Modify: `templates/partials/document.html:11-17`
+- Modify: `static/style.css`
+
+**Step 1: Make the regen-status feedback visible**
+
+In `templates/partials/document.html`, the `.regen-status` span (line 17) has no styling and is inline. Replace lines 11-17 with a version that provides clear visual feedback:
+
+```html
+<button class="btn btn-sm btn-export"
+        hx-post="/web/specs/{{ spec_id }}/regenerate"
+        hx-target=".regen-status" hx-swap="innerHTML"
+        hx-indicator=".btn-export"
+        title="Save exports to disk">
+    Export to Disk
+</button>
+<span class="regen-status"></span>
+```
+
+**Step 2: Add CSS for the confirmation message and loading state**
+
+Append to `static/style.css`:
+
+```css
+/* Export button loading indicator */
+.btn-export.htmx-request {
+    opacity: 0.5;
+    pointer-events: none;
+}
+/* Regen confirmation flash */
+.regen-status {
+    font-size: 12px;
+    color: var(--success);
+    font-weight: 500;
+    transition: opacity 0.3s;
+}
+.regen-confirm {
+    animation: regenFlash 3s ease-out forwards;
+}
+@keyframes regenFlash {
+    0% { opacity: 1; }
+    70% { opacity: 1; }
+    100% { opacity: 0; }
+}
+```
+
+**Step 3: Build and verify**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: compilation succeeds.
+
+**Step 4: Commit**
+
+```bash
+git add templates/partials/document.html static/style.css
+git commit -m "fix: make Export to Disk feedback visible with loading state (#16)"
+```
+
+---
+
+### Task 9: Run full test suite and clippy
+
+**Step 1: Run all tests**
+
+Run: `cargo test --all 2>&1 | tail -30`
+Expected: all tests pass (note: `export::dot::tests::long_prompts_are_truncated` may fail intermittently due to pre-existing ULID ordering nondeterminism — this is not caused by our changes).
+
+**Step 2: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings 2>&1 | tail -20`
+Expected: no warnings.
+
+**Step 3: Fix any issues found, then commit if needed**
+
+---
+
+## Excluded Issues
+
+- **#5** (Context loss): Agent-side architecture issue, not a UI fix.
+- **#9** (Backend correct after refresh): Confirms backend is fine, no action needed.
+- **#11** (Document/Spec tabs): Already fixed in this feature branch.
+- **#13** (Token-by-token streaming): Deferred to separate effort — requires LLM provider → SSE streaming pipeline.
+
+## Task Order & Dependencies
+
+```
+Task 1 (quick wins)     ─┐
+Task 2 (throbber)        ├── independent, can run in any order
+Task 3 (multi-select)    │
+Task 4 (chat width)     ─┘
+Task 5 (phase polling)  ── depends on knowing route patterns (read Task 5 carefully)
+Task 6 (sidebar refresh) ── independent
+Task 7 (error messages)  ── touches both agent + server crates
+Task 8 (export button)   ── independent
+Task 9 (full test suite) ── must be last
+```

--- a/docs/plans/2026-04-17-phase-wayfinding-design.md
+++ b/docs/plans/2026-04-17-phase-wayfinding-design.md
@@ -1,0 +1,80 @@
+# Phase Wayfinding — Information Architecture Redesign
+
+## Problem
+
+The command bar crams identity, phase status, phase transitions, view toggles, and agent controls into a single 56px row with no visual hierarchy. A new user sees 8+ clickable elements at the same level and has no idea what's structural vs. what's dangerous (phase transitions).
+
+## Design
+
+### Layered Layout
+
+Four concerns, four layers:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Title › One-liner                        [● Agents active] │  Command bar (identity + status)
+├──────────────────────────────────────────────────────────┤
+│    ① Brainstorm ────── ② Refine ────── ③ Complete         │  Phase stepper (wayfinding)
+├──────────────────────────────────────────────────────────┤
+│                [Document] [Board] [Workflow]                │  View toggles (contextual)
+├──────────────────────────────────────────────────────────┤
+│                                                            │
+│                     Content area                           │
+│                                                            │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Row 1 — Command bar:** Spec identity on the left, agent status pill on the right. Nothing else.
+
+**Row 2 — Phase stepper:** Always visible. Shows Brainstorm → Refine → Complete as a linear progression with numbered circles connected by lines (like a checkout flow).
+
+**Row 3 — View toggles:** Only rendered when the active phase has toggles. Currently only Refining (Document / Board / Workflow). Designed as a reusable component so other phases can add toggles later without structural changes.
+
+**Row 4 — Content area:** Unchanged from current behavior.
+
+### Phase Stepper Behavior
+
+The stepper replaces all phase transition buttons ("Finalize Spec", "Resume Brainstorming", "Keep Refining") with direct navigation.
+
+**Step states:**
+- **Completed:** Filled/checked circle, solid connector line, clickable — navigates to that phase
+- **Active:** Highlighted/accent circle, bold label — you are here
+- **Upcoming (disabled):** Muted/gray circle, faded connector, not clickable — tooltip on hover explains prerequisite (e.g., "Complete brainstorming to unlock refining")
+
+**Transitions:** Clicking a step POSTs to the existing `/web/specs/{id}/phase` endpoint. The stepper is a better UI for the same backend action.
+
+**Onboarding:** A new user starting a spec sees Brainstorm active, Refine and Complete grayed out with tooltips. They immediately understand the lifecycle without explanation.
+
+### View Toggles Component
+
+A reusable pill-capsule partial that takes a list of toggle definitions (label, icon, endpoint) and the active view. Each phase template decides whether to include it and with what options.
+
+Currently only Refining populates it with Document / Board / Workflow. Brainstorming may add Chat / Context / Code in the future.
+
+### What Gets Removed
+
+- Phase badge markup and CSS (`REFINING` / `BRAINSTORMING` / `COMPLETE`)
+- "Finalize Spec" button
+- "Resume Brainstorming" button
+- "Keep Refining" button
+- "View Board" / "Back to Chat" toggle hack in brainstorming
+- Hardcoded view toggles in the command bar
+
+### What Gets Added
+
+- `templates/partials/phase_stepper.html` — stepper partial, takes current phase
+- `templates/partials/view_toggles.html` — toggle partial, takes toggle list + active view
+- Stepper and toggle CSS in `static/style.css`
+
+### What Moves
+
+- Download .md button moves from command bar into the document canvas content (Complete phase)
+- Agent status pill stays in command bar but is now the only control there
+
+### What's Preserved
+
+- All existing API endpoints (phase transitions, view loading, agent control)
+- SSE event handling and phase polling fallback
+- Agent status pill behavior and offline overlay
+- Chat rail in Refining phase
+- Content rendering for all phases

--- a/docs/plans/2026-04-17-phase-wayfinding-implementation.md
+++ b/docs/plans/2026-04-17-phase-wayfinding-implementation.md
@@ -1,0 +1,851 @@
+# Phase Wayfinding Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the overloaded command bar with a layered layout: simplified command bar, linear phase stepper, and contextual view toggles.
+
+**Architecture:** Three horizontal layers replace the single command bar. The phase stepper is a new Askama partial that renders Brainstorm → Refine → Complete as a clickable linear progression. View toggles become a reusable partial that only renders when the active phase has sub-views. Phase transition buttons are eliminated — clicking stepper steps IS the transition.
+
+**Tech Stack:** Rust/Axum backend, Askama templates, HTMX, vanilla CSS, SSE for live updates.
+
+**Design doc:** `docs/plans/2026-04-17-phase-wayfinding-design.md`
+
+---
+
+### Task 1: Phase Stepper CSS
+
+Add CSS for the stepper component before touching any templates.
+
+**Files:**
+- Modify: `static/style.css`
+
+**Step 1: Add stepper CSS after the view-toggle rules (~line 216)**
+
+Add these rules after the existing `.view-toggle-label` media query block:
+
+```css
+/* --- Phase stepper --- */
+.phase-stepper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    padding: 12px 20px;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.phase-step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font-body);
+    color: var(--text-muted);
+    transition: all 0.2s;
+    white-space: nowrap;
+    position: relative;
+}
+
+.phase-step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    font-size: 12px;
+    font-weight: 600;
+    border: 2px solid var(--border);
+    color: var(--text-muted);
+    background: var(--bg-card);
+    transition: all 0.2s;
+    flex-shrink: 0;
+}
+
+.phase-step-label {
+    transition: color 0.2s;
+}
+
+/* Connector line between steps */
+.phase-step-connector {
+    width: 48px;
+    height: 2px;
+    background: var(--border);
+    flex-shrink: 0;
+    transition: background 0.2s;
+}
+
+/* Active step */
+.phase-step.step-active {
+    cursor: default;
+    color: var(--text-primary);
+}
+.phase-step.step-active .phase-step-number {
+    background: var(--text-primary);
+    border-color: var(--text-primary);
+    color: var(--bg-card);
+}
+
+/* Completed step */
+.phase-step.step-completed {
+    color: var(--text-primary);
+}
+.phase-step.step-completed:hover {
+    opacity: 0.7;
+}
+.phase-step.step-completed .phase-step-number {
+    background: var(--success, #22c55e);
+    border-color: var(--success, #22c55e);
+    color: #fff;
+}
+
+/* Completed connector */
+.phase-step-connector.connector-completed {
+    background: var(--success, #22c55e);
+}
+
+/* Disabled/upcoming step */
+.phase-step.step-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+.phase-step.step-disabled .phase-step-number {
+    border-style: dashed;
+}
+```
+
+**Step 2: Verify CSS is valid**
+
+Run: `cargo build --all 2>&1 | head -5`
+Expected: build succeeds (CSS is static, not compiled, but this verifies nothing else broke)
+
+**Step 3: Commit**
+
+```bash
+git add static/style.css
+git commit -m "style: add phase stepper CSS"
+```
+
+---
+
+### Task 2: Phase Stepper Template
+
+Create the Askama partial for the phase stepper.
+
+**Files:**
+- Create: `templates/partials/phase_stepper.html`
+- Modify: `crates/barnstormer-server/src/web/mod.rs` (add template struct)
+
+**Step 1: Create the stepper template**
+
+Create `templates/partials/phase_stepper.html`:
+
+```html
+{# ABOUTME: Linear phase stepper showing Brainstorm → Refine → Complete progression. #}
+{# ABOUTME: Clickable steps trigger phase transitions via HTMX POST. #}
+
+{% let phases = [("brainstorming", "Brainstorm", "1"), ("refining", "Refine", "2"), ("complete", "Complete", "3")] %}
+
+<nav class="phase-stepper" aria-label="Spec phases">
+    {% for (phase_id, label, number) in phases %}
+    {% if !loop.first %}
+    <div class="phase-step-connector{% if self.is_completed(phase_id) %} connector-completed{% endif %}"></div>
+    {% endif %}
+
+    {% if *phase_id == phase %}
+    <div class="phase-step step-active" aria-current="step">
+        <span class="phase-step-number">{{ number }}</span>
+        <span class="phase-step-label">{{ label }}</span>
+    </div>
+    {% else if self.is_completed(phase_id) %}
+    <button class="phase-step step-completed"
+            hx-post="/web/specs/{{ spec_id }}/phase"
+            hx-vals='{"target":"{{ phase_id }}"}'
+            hx-swap="none"
+            title="Return to {{ label }}">
+        <span class="phase-step-number">✓</span>
+        <span class="phase-step-label">{{ label }}</span>
+    </button>
+    {% else %}
+    <div class="phase-step step-disabled"
+         title="{{ self.disabled_tooltip(phase_id) }}">
+        <span class="phase-step-number">{{ number }}</span>
+        <span class="phase-step-label">{{ label }}</span>
+    </div>
+    {% endif %}
+    {% endfor %}
+</nav>
+```
+
+**Step 2: Add the template struct and helper methods in Rust**
+
+In `crates/barnstormer-server/src/web/mod.rs`, add this struct near the other template structs (around line 579):
+
+```rust
+/// Phase stepper navigation partial.
+#[derive(Template)]
+#[template(path = "partials/phase_stepper.html")]
+pub struct PhaseStepperTemplate {
+    pub spec_id: String,
+    pub phase: String,
+}
+
+impl PhaseStepperTemplate {
+    /// A phase is "completed" if the current phase is further along in the lifecycle.
+    fn is_completed(&self, phase_id: &str) -> bool {
+        let order = |p: &str| match p {
+            "brainstorming" => 0,
+            "refining" => 1,
+            "complete" => 2,
+            _ => 99,
+        };
+        order(phase_id) < order(&self.phase)
+    }
+
+    /// Tooltip text explaining why a future phase is disabled.
+    fn disabled_tooltip(&self, phase_id: &str) -> &'static str {
+        match phase_id {
+            "refining" => "Complete brainstorming to unlock refining",
+            "complete" => "Refine the spec before finalizing",
+            _ => "",
+        }
+    }
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cargo build --all 2>&1 | tail -3`
+Expected: build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add templates/partials/phase_stepper.html crates/barnstormer-server/src/web/mod.rs
+git commit -m "feat: add phase stepper template and helpers"
+```
+
+---
+
+### Task 3: View Toggles Reusable Partial
+
+Extract the hardcoded view toggles from `spec_view.html` into a reusable partial.
+
+**Files:**
+- Create: `templates/partials/view_toggles.html`
+- Modify: `crates/barnstormer-server/src/web/mod.rs` (add template struct)
+
+**Step 1: Create the view toggles partial template**
+
+Create `templates/partials/view_toggles.html`:
+
+```html
+{# ABOUTME: Reusable view toggle capsule for phase-specific sub-navigation. #}
+{# ABOUTME: Takes a list of toggles and renders a pill-capsule selector bar. #}
+
+{% if !toggles.is_empty() %}
+<div class="view-toggles-row">
+    <div class="view-toggles-capsule">
+        {% for toggle in toggles %}
+        <button class="view-toggle{% if toggle.id == active_view %} active{% endif %}"
+                data-view="{{ toggle.id }}"
+                hx-get="/web/specs/{{ spec_id }}/{{ toggle.endpoint }}"
+                hx-target="#canvas" hx-swap="innerHTML">
+            {{ toggle.icon|safe }}
+            <span class="view-toggle-label">{{ toggle.label }}</span>
+        </button>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+```
+
+**Step 2: Add the template struct and toggle data type**
+
+In `crates/barnstormer-server/src/web/mod.rs`, add near the other template structs:
+
+```rust
+/// A single toggle option for the view toggles bar.
+pub struct ViewToggle {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub endpoint: &'static str,
+    pub icon: &'static str,
+}
+
+/// View toggles partial — reusable sub-navigation capsule.
+#[derive(Template)]
+#[template(path = "partials/view_toggles.html")]
+pub struct ViewTogglesTemplate {
+    pub spec_id: String,
+    pub active_view: String,
+    pub toggles: Vec<ViewToggle>,
+}
+```
+
+**Step 3: Add a helper function that returns the refining toggles**
+
+This avoids repeating the SVG icons everywhere:
+
+```rust
+/// Returns the view toggles for the Refining phase.
+pub fn refining_toggles() -> Vec<ViewToggle> {
+    vec![
+        ViewToggle {
+            id: "document",
+            label: "Document",
+            endpoint: "document",
+            icon: r#"<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>"#,
+        },
+        ViewToggle {
+            id: "board",
+            label: "Board",
+            endpoint: "board",
+            icon: r#"<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>"#,
+        },
+        ViewToggle {
+            id: "spec",
+            label: "Workflow",
+            endpoint: "spec",
+            icon: r#"<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>"#,
+        },
+    ]
+}
+```
+
+**Step 4: Add CSS for the view-toggles-row wrapper**
+
+In `static/style.css`, add after the existing `.view-toggle.active` rules (~line 209):
+
+```css
+/* View toggles row — sits below stepper when phase has sub-views */
+.view-toggles-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 20px;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+```
+
+**Step 5: Verify it compiles**
+
+Run: `cargo build --all 2>&1 | tail -3`
+Expected: build succeeds
+
+**Step 6: Commit**
+
+```bash
+git add templates/partials/view_toggles.html crates/barnstormer-server/src/web/mod.rs static/style.css
+git commit -m "feat: add reusable view toggles partial"
+```
+
+---
+
+### Task 4: Refactor spec_view.html — Brainstorming Phase
+
+Replace the brainstorming section of `spec_view.html` with the new layered layout.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html:4-117` (brainstorming block)
+
+**Step 1: Replace the brainstorming phase block**
+
+Replace lines 4-117 of `spec_view.html` (the `{% if phase == "brainstorming" %}` block through its closing script tag) with:
+
+```html
+{# Brainstorming layout: simplified command bar + stepper + full-width chat #}
+<div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream"
+     data-view="brainstorming">
+
+<header class="command-bar">
+    <div class="command-bar-left">
+        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-chevron">&#8250;</span>
+        <span class="command-bar-subtitle">{{ one_liner }}</span>
+    </div>
+    <div class="command-bar-right">
+        <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
+             hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
+             hx-swap="innerHTML"></div>
+    </div>
+</header>
+
+{% include "partials/phase_stepper.html" %}
+
+<div class="spec-body">
+    <main class="canvas" id="canvas"
+          hx-get="/web/specs/{{ spec_id }}/chat-panel"
+          hx-trigger="load" hx-swap="innerHTML">
+    </main>
+    {% if has_pending_question %}
+    {% match canvas_content %}
+    {% when Some with (content) %}
+    <div id="agent-canvas" style="display:block;">{{ content|safe }}</div>
+    {% when None %}
+    <div id="agent-canvas" style="display:none;"></div>
+    {% endmatch %}
+    {% else %}
+    <div id="agent-canvas" style="display:none;"></div>
+    {% endif %}
+</div>
+<div id="agents-offline-banner" class="agents-offline-banner">
+    <button class="agents-offline-dismiss" onclick="this.parentElement.style.display='none'" title="Dismiss">&times;</button>
+    <span>Agents are not running.</span>
+    <button class="btn btn-start-agents"
+            hx-post="/web/specs/{{ spec_id }}/agents/start"
+            hx-target="#agent-controls"
+            hx-swap="innerHTML">Start Agents</button>
+</div>
+
+</div>
+
+<script>
+    (function() {
+        var compositor = document.querySelector('.spec-compositor');
+        if (compositor) {
+            compositor.addEventListener('sse:phase_transitioned', function() {
+                htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+            });
+
+            compositor.addEventListener('sse:canvas_updated', function(evt) {
+                var data = JSON.parse(evt.detail.data);
+                var canvas = document.getElementById('agent-canvas');
+                var content = data.payload && data.payload.content;
+                if (content && content.trim() !== '') {
+                    canvas.innerHTML = content;
+                    canvas.style.display = 'block';
+                } else {
+                    canvas.innerHTML = '';
+                    canvas.style.display = 'none';
+                }
+            });
+
+            compositor.addEventListener('sse:question_answered', function() {
+                var canvas = document.getElementById('agent-canvas');
+                if (canvas) {
+                    canvas.innerHTML = '';
+                    canvas.style.display = 'none';
+                }
+            });
+
+            var currentPhase = '{{ phase }}';
+            setInterval(function() {
+                fetch('/web/specs/{{ spec_id }}/phase-check')
+                    .then(function(r) { return r.text(); })
+                    .then(function(serverPhase) {
+                        if (serverPhase !== currentPhase) {
+                            htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+                        }
+                    })
+                    .catch(function() {});
+            }, 15000);
+        }
+    })();
+</script>
+```
+
+**Key changes:**
+- Phase badge removed from command bar
+- "View Board" / "Back to Chat" buttons removed (will become view toggles later)
+- Phase stepper included via `{% include %}`
+- No view toggles row (brainstorming has none yet)
+
+**Step 2: Verify it compiles**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: build succeeds
+
+**Step 3: Verify tests pass**
+
+Run: `cargo test --all 2>&1 | tail -10`
+Expected: all tests pass
+
+**Step 4: Commit**
+
+```bash
+git add templates/partials/spec_view.html
+git commit -m "refactor: brainstorming phase uses layered command bar + stepper"
+```
+
+---
+
+### Task 5: Refactor spec_view.html — Refining Phase
+
+Replace the refining section with the new layered layout.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html` (refining block, currently `{% else if phase == "refining" %}`)
+
+**Step 1: Replace the refining phase block**
+
+Replace the entire `{% else if phase == "refining" %}` block (currently lines 119-245 area) with:
+
+```html
+{% else if phase == "refining" %}
+{# Refining layout: command bar + stepper + view toggles + canvas + chat rail #}
+<div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream">
+
+<header class="command-bar">
+    <div class="command-bar-left">
+        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-chevron">&#8250;</span>
+        <span class="command-bar-subtitle">{{ one_liner }}</span>
+    </div>
+    <div class="command-bar-right">
+        <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
+             hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
+             hx-swap="innerHTML"></div>
+    </div>
+</header>
+
+{% include "partials/phase_stepper.html" %}
+
+<div class="view-toggles-row">
+    <div class="view-toggles-capsule">
+        <button class="view-toggle active" data-view="document"
+                hx-get="/web/specs/{{ spec_id }}/document"
+                hx-target="#canvas" hx-swap="innerHTML">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+            <span class="view-toggle-label">Document</span>
+        </button>
+        <button class="view-toggle" data-view="board"
+                hx-get="/web/specs/{{ spec_id }}/board"
+                hx-target="#canvas" hx-swap="innerHTML">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+            <span class="view-toggle-label">Board</span>
+        </button>
+        <button class="view-toggle" data-view="spec"
+                hx-get="/web/specs/{{ spec_id }}/spec"
+                hx-target="#canvas" hx-swap="innerHTML">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>
+            <span class="view-toggle-label">Workflow</span>
+        </button>
+    </div>
+</div>
+
+<div class="spec-body">
+    <main class="canvas" id="canvas"
+          hx-get="/web/specs/{{ spec_id }}/document"
+          hx-trigger="load" hx-swap="innerHTML">
+    </main>
+    <aside class="chat-rail" id="chat-rail"
+           hx-get="/web/specs/{{ spec_id }}/chat-panel"
+           hx-trigger="load" hx-swap="innerHTML">
+    </aside>
+</div>
+<div id="agents-offline-banner" class="agents-offline-banner">
+    <button class="agents-offline-dismiss" onclick="this.parentElement.style.display='none'" title="Dismiss">&times;</button>
+    <span>Agents are not running.</span>
+    <button class="btn btn-start-agents"
+            hx-post="/web/specs/{{ spec_id }}/agents/start"
+            hx-target="#agent-controls"
+            hx-swap="innerHTML">Start Agents</button>
+</div>
+
+</div>
+
+<script>
+    // View toggle active state management
+    document.querySelectorAll('.view-toggles-capsule .view-toggle').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            document.querySelectorAll('.view-toggles-capsule .view-toggle').forEach(function(b) {
+                b.classList.remove('active');
+            });
+            btn.classList.add('active');
+        });
+    });
+
+    document.body.addEventListener('htmx:afterSwap', function(evt) {
+        if (evt.detail.target && evt.detail.target.id === 'agent-status') {
+            document.body.dispatchEvent(new CustomEvent('refreshAgents'));
+        }
+    });
+
+    (function() {
+        var refreshTimer = null;
+        var sseEvents = ['card_created', 'card_updated', 'card_moved', 'card_deleted', 'spec_core_updated'];
+        var compositor = document.querySelector('.spec-compositor');
+        if (!compositor) return;
+
+        sseEvents.forEach(function(eventName) {
+            compositor.addEventListener('sse:' + eventName, function() {
+                if (refreshTimer) clearTimeout(refreshTimer);
+                refreshTimer = setTimeout(function() {
+                    var canvas = document.getElementById('canvas');
+                    if (!canvas) return;
+                    var activeBtn = document.querySelector('.view-toggle.active');
+                    if (activeBtn) {
+                        activeBtn.click();
+                    }
+                }, 800);
+            });
+        });
+
+        compositor.addEventListener('sse:phase_transitioned', function() {
+            htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+        });
+
+        var currentPhase = '{{ phase }}';
+        setInterval(function() {
+            fetch('/web/specs/{{ spec_id }}/phase-check')
+                .then(function(r) { return r.text(); })
+                .then(function(serverPhase) {
+                    if (serverPhase !== currentPhase) {
+                        htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+                    }
+                })
+                .catch(function() {});
+        }, 15000);
+    })();
+</script>
+```
+
+**Key changes:**
+- Phase badge removed
+- "Finalize Spec" and "Resume Brainstorming" buttons removed
+- View toggles capsule moved from command bar to its own row below stepper
+- Phase stepper included via `{% include %}`
+- Agent controls is the only thing in command-bar-right
+
+**Note:** We inline the view toggles here rather than using the `ViewTogglesTemplate` partial because Askama `{% include %}` shares the parent template's variables. The reusable partial struct from Task 3 is available for programmatic use (e.g., HTMX fragment responses) but the inline approach is simpler for the main spec_view template.
+
+**Step 2: Verify it compiles**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: build succeeds
+
+**Step 3: Verify tests pass**
+
+Run: `cargo test --all 2>&1 | tail -10`
+Expected: all tests pass
+
+**Step 4: Commit**
+
+```bash
+git add templates/partials/spec_view.html
+git commit -m "refactor: refining phase uses layered command bar + stepper + toggle row"
+```
+
+---
+
+### Task 6: Refactor spec_view.html — Complete Phase
+
+Replace the complete section with the new layered layout. Move the Download button into the document template.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html` (complete block, `{% else %}`)
+- Modify: `templates/partials/document.html` (add download button)
+
+**Step 1: Add a download action bar to the document template**
+
+In `templates/partials/document.html`, add a download bar inside the existing `.document-notice` div. Replace the current notice div (lines 2-19) with:
+
+```html
+    <div class="document-notice">
+        <span class="notice-icon">&#9432;</span>
+        Auto-generated from spec data. Edit cards on the Board to update this document.
+        <button class="btn btn-sm btn-regen"
+                hx-get="/web/specs/{{ spec_id }}/document"
+                hx-target="#canvas" hx-swap="innerHTML"
+                title="Refresh document from current spec data">
+            Regenerate
+        </button>
+        <button class="btn btn-sm btn-export"
+                hx-post="/web/specs/{{ spec_id }}/regenerate"
+                hx-target=".regen-status" hx-swap="innerHTML"
+                hx-indicator=".btn-export"
+                title="Save exports to disk">
+            Export to Disk
+        </button>
+        <a href="/web/specs/{{ spec_id }}/export/markdown" download class="btn btn-sm">Download .md</a>
+        <span class="regen-status"></span>
+    </div>
+```
+
+**Step 2: Replace the complete phase block in spec_view.html**
+
+Replace the `{% else %}` block (complete phase) with:
+
+```html
+{% else %}
+{# Complete layout: command bar + stepper + read-only document #}
+<div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream">
+
+<header class="command-bar">
+    <div class="command-bar-left">
+        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-chevron">&#8250;</span>
+        <span class="command-bar-subtitle">{{ one_liner }}</span>
+    </div>
+    <div class="command-bar-right">
+    </div>
+</header>
+
+{% include "partials/phase_stepper.html" %}
+
+<div class="spec-body">
+    <main class="canvas" id="canvas"
+          hx-get="/web/specs/{{ spec_id }}/document"
+          hx-trigger="load" hx-swap="innerHTML">
+    </main>
+</div>
+
+</div>
+
+<script>
+    (function() {
+        var compositor = document.querySelector('.spec-compositor');
+        if (compositor) {
+            compositor.addEventListener('sse:phase_transitioned', function() {
+                htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+            });
+
+            var currentPhase = '{{ phase }}';
+            setInterval(function() {
+                fetch('/web/specs/{{ spec_id }}/phase-check')
+                    .then(function(r) { return r.text(); })
+                    .then(function(serverPhase) {
+                        if (serverPhase !== currentPhase) {
+                            htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+                        }
+                    })
+                    .catch(function() {});
+            }, 15000);
+        }
+    })();
+</script>
+
+{% endif %}
+```
+
+**Key changes:**
+- "Download .md" link removed from command bar (now in document.html notice bar)
+- "Keep Refining" button removed (stepper step 2 handles it)
+- No agent controls in complete phase (agents aren't relevant for read-only view)
+- Phase stepper shows ✓ Brainstorm ✓ Refine ● Complete
+
+**Step 3: Verify it compiles**
+
+Run: `cargo build --all 2>&1 | tail -5`
+Expected: build succeeds
+
+**Step 4: Verify tests pass**
+
+Run: `cargo test --all 2>&1 | tail -10`
+Expected: all tests pass
+
+**Step 5: Commit**
+
+```bash
+git add templates/partials/spec_view.html templates/partials/document.html
+git commit -m "refactor: complete phase uses stepper, download moves to document view"
+```
+
+---
+
+### Task 7: Clean Up Obsolete CSS
+
+Remove CSS that's no longer used (phase badges in the command bar) and verify nothing breaks.
+
+**Files:**
+- Modify: `static/style.css`
+
+**Step 1: Remove the phase badge CSS**
+
+Delete the `.phase-badge`, `.phase-brainstorming`, `.phase-refining`, and `.phase-complete` rules (around lines 1579-1600 in current file).
+
+**Step 2: Verify no templates still reference phase badges**
+
+Run: `grep -r "phase-badge\|phase-brainstorming\|phase-refining\|phase-complete" templates/`
+Expected: no matches (the stepper uses different class names)
+
+**Step 3: Check that the phase transition endpoint response still works**
+
+The `transition_phase` handler at `crates/barnstormer-server/src/web/mod.rs:2186-2196` returns `<span class="phase-badge">...</span>`. Since phase transitions now trigger SSE `phase_transitioned` events which reload the entire workspace, the response body isn't displayed. But update it to return a simple success message instead:
+
+In `crates/barnstormer-server/src/web/mod.rs`, replace lines 2186-2196:
+
+```rust
+        Ok(_) => {
+            // Phase transition triggers SSE phase_transitioned event,
+            // which causes the client to reload the entire workspace.
+            // Return minimal success response.
+            (StatusCode::OK, Html("<span>OK</span>".to_string())).into_response()
+        }
+```
+
+**Step 4: Verify tests pass**
+
+Run: `cargo test --all 2>&1 | tail -10`
+Expected: all tests pass
+
+**Step 5: Commit**
+
+```bash
+git add static/style.css crates/barnstormer-server/src/web/mod.rs
+git commit -m "chore: remove obsolete phase badge CSS and clean up transition response"
+```
+
+---
+
+### Task 8: Visual Verification
+
+Verify the new layout works correctly in the browser across all three phases.
+
+**Files:**
+- No file changes — this is a manual verification task
+
+**Step 1: Start the dev server**
+
+Run: `cargo run -- start --no-open`
+
+**Step 2: Verify brainstorming phase**
+
+Open a spec that's in brainstorming phase:
+- Command bar shows title + one-liner on left, agent pill on right
+- Stepper shows: **● Brainstorm** ——— Refine ——— Complete
+- Refine and Complete steps are grayed out / disabled
+- Hovering disabled steps shows tooltips
+- No phase badge visible
+- No "View Board" / "Back to Chat" buttons
+- Chat and canvas area work normally
+
+**Step 3: Verify refining phase**
+
+Open a spec that's in refining phase (or transition one):
+- Command bar shows title + one-liner on left, agent pill on right
+- Stepper shows: **✓ Brainstorm** ——— **● Refine** ——— Complete
+- Brainstorm step is clickable (completed), Complete is disabled
+- View toggles row shows Document / Board / Workflow below stepper
+- No "Finalize Spec" or "Resume Brainstorming" buttons
+- Clicking Brainstorm step in stepper transitions back to brainstorming
+- Chat rail and canvas work normally
+
+**Step 4: Verify complete phase**
+
+Open a spec in complete phase (or transition one):
+- Stepper shows: **✓ Brainstorm** ——— **✓ Refine** ——— **● Complete**
+- Both completed steps are clickable
+- No view toggles row
+- Download .md button is inside the document notice bar
+- No agent controls (command-bar-right is empty)
+
+**Step 5: Verify stepper transitions work**
+
+- From refining, click ✓ Brainstorm — page reloads as brainstorming layout
+- From brainstorming, verify Refine step is disabled (can't skip ahead)
+- From complete, click ✓ Refine — page reloads as refining layout
+
+**Step 6: Commit any fixes if needed**
+
+If visual issues are found, fix and commit with descriptive messages.

--- a/docs/plans/2026-04-20-mobile-ui-cleanup-design.md
+++ b/docs/plans/2026-04-20-mobile-ui-cleanup-design.md
@@ -1,0 +1,39 @@
+# Mobile UI Cleanup Design
+
+## Goal
+
+Make the barnstormer web UI fully usable on mobile devices (≤900px), addressing layout overflow, missing navigation, and awkward content splits.
+
+## Current State
+
+Single breakpoint at 900px. On mobile: sidebar collapses to a cramped horizontal strip, phase stepper overflows, refining mode keeps the 380px chat rail side-by-side with the canvas (unusable on phones), view toggles become anonymous icons, and the subtitle disappears with no way to see it.
+
+## Design
+
+### 1. Subtitle Popover (mobile only)
+
+On mobile, the command bar title becomes tappable. Clicking shows a small floating popover below with the subtitle text. Tap outside or tap title again to dismiss. Desktop behavior unchanged (subtitle always visible inline).
+
+### 2. Hamburger Menu + Sidebar Drawer
+
+Add a hamburger icon to the left side of the command bar on mobile (hidden on desktop). Tapping opens the nav rail as a slide-in overlay from the left with a semi-transparent backdrop. Sidebar takes ~80% of screen width. Dismiss by tapping backdrop or hamburger. The current horizontal strip layout for the nav rail is removed on mobile.
+
+### 3. Refining Mode: Tabbed Layout (mobile only)
+
+Replace the side-by-side canvas + chat rail split with a tab switcher on mobile. Two tabs at the bottom of the toolbar area: the active view name (Document/Board/Spec) and "Chat". Default to Document tab on load. The view toggles (Document/Board/Spec) remain in the Document tab context. CSS-only toggle using a class on the spec-body to show/hide canvas vs chat-rail.
+
+### 4. Phase Stepper Responsiveness
+
+On mobile, hide connector lines and non-active step labels. Show compact format: step numbers for inactive steps, number + label for the active step. Example: `(1) — Refine — (3)` instead of full `Brainstorm ------- Refine ------- Complete`.
+
+### 5. View Toggles: Show Active Label
+
+On mobile, keep icons-only for inactive toggles but show the label for the currently active toggle. Example: `[doc-icon Document] [board-icon] [spec-icon]` — gives context for which view is active without taking too much space.
+
+## Breakpoint
+
+All changes apply at the existing `@media (max-width: 900px)` breakpoint. No new breakpoints needed.
+
+## Approach
+
+CSS-first where possible, minimal JS for interactive behaviors (hamburger toggle, subtitle popover, mobile tab switcher). No new endpoints or template restructuring — use classes and display toggling.

--- a/docs/plans/2026-04-20-mobile-ui-cleanup-implementation.md
+++ b/docs/plans/2026-04-20-mobile-ui-cleanup-implementation.md
@@ -1,0 +1,460 @@
+# Mobile UI Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the barnstormer web UI fully usable on mobile (≤900px) with hamburger sidebar, mobile tabs, responsive stepper, subtitle popover, and active view label.
+
+**Architecture:** CSS-first with minimal JS. All changes gate behind the existing `@media (max-width: 900px)` breakpoint. Interactive behaviors (hamburger, subtitle popover, mobile tab switcher) use vanilla JS with class toggles. No new server endpoints or Askama template restructuring needed.
+
+**Tech Stack:** CSS media queries, vanilla JS, Askama templates, HTMX
+
+---
+
+### Task 1: Hamburger menu + sidebar drawer
+
+Add a hamburger button (mobile only) to the command bar. Clicking opens the nav-rail as a slide-in overlay from the left with a backdrop. The existing horizontal-strip mobile nav is replaced with a hidden drawer.
+
+**Files:**
+- Modify: `templates/base.html:27-30`
+- Modify: `static/style.css:1689-1714` (mobile media query)
+- Modify: `static/style.css:72-85` (app-layout, nav-rail base styles)
+
+**Step 1: Add hamburger button and backdrop to base.html**
+
+In `templates/base.html`, add a hamburger button inside `.app-layout` before the nav-rail, and a backdrop div after the nav-rail:
+
+```html
+<div class="app-layout">
+    <button class="hamburger" onclick="document.querySelector('.app-layout').classList.toggle('nav-open')" aria-label="Toggle navigation">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <nav class="nav-rail">{% block nav %}{% endblock %}</nav>
+    <div class="nav-backdrop" onclick="document.querySelector('.app-layout').classList.remove('nav-open')"></div>
+    <div class="workspace" id="workspace">{% block workspace %}{% endblock %}</div>
+</div>
+```
+
+**Step 2: Add hamburger and drawer CSS**
+
+Add to `static/style.css` — base styles (hidden on desktop):
+
+```css
+/* Hamburger menu — hidden on desktop, shown on mobile */
+.hamburger {
+    display: none;
+    position: fixed;
+    top: 12px;
+    left: 12px;
+    z-index: 51;
+    border: none;
+    background: var(--bg-card);
+    border-radius: 8px;
+    padding: 8px;
+    cursor: pointer;
+    color: var(--text-primary);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Backdrop for mobile nav drawer */
+.nav-backdrop {
+    display: none;
+}
+```
+
+Inside `@media (max-width: 900px)`:
+
+```css
+.hamburger {
+    display: flex;
+}
+
+.nav-rail {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 80vw;
+    max-width: 320px;
+    z-index: 50;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    border-right: 1px solid var(--border);
+    border-bottom: none;
+    max-height: none;
+}
+
+.app-layout.nav-open .nav-rail {
+    transform: translateX(0);
+}
+
+.nav-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 49;
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.app-layout.nav-open .nav-backdrop {
+    display: block;
+}
+
+/* Offset command bar for hamburger button */
+.command-bar {
+    padding-left: 52px;
+}
+```
+
+Remove the old mobile nav-rail rules (the horizontal strip behavior: `border-bottom`, `max-height: 200px`).
+
+**Step 3: Update mobile app-layout grid**
+
+The mobile grid no longer needs a row for the nav. Change to:
+
+```css
+.app-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test --all
+```
+
+All existing tests should still pass (template rendering tests don't test mobile CSS).
+
+**Step 5: Visual verification**
+
+Open http://127.0.0.1:7331 in a 390px-wide viewport. Verify:
+- Hamburger icon visible top-left
+- Clicking opens sidebar drawer from left with backdrop
+- Clicking backdrop closes drawer
+- Sidebar takes ~80% width, full height
+- Desktop view unchanged (hamburger hidden)
+
+**Step 6: Commit**
+
+```bash
+git add templates/base.html static/style.css
+git commit -m "feat: add hamburger menu and sidebar drawer for mobile"
+```
+
+---
+
+### Task 2: Subtitle popover (mobile only)
+
+Make the command bar title tappable on mobile. Clicking shows a floating popover with the subtitle text. Tap outside or tap title again to dismiss.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html:9-14,100-105,222-227` (all three command-bar instances)
+- Modify: `static/style.css` (add popover styles)
+
+**Step 1: Add popover markup to command bar**
+
+In each of the three `<header class="command-bar">` blocks in `spec_view.html`, wrap the title in a clickable container with a popover:
+
+```html
+<div class="command-bar-left">
+    <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
+    <span class="command-bar-chevron">&#8250;</span>
+    <span class="command-bar-subtitle">{{ one_liner }}</span>
+    <div class="command-bar-popover">{{ one_liner }}</div>
+</div>
+```
+
+**Step 2: Add popover CSS**
+
+Add base styles (hidden by default):
+
+```css
+.command-bar-popover {
+    display: none;
+}
+```
+
+Inside `@media (max-width: 900px)`:
+
+```css
+.command-bar-title {
+    cursor: pointer;
+}
+
+.command-bar-popover {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    padding: 8px 16px;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    font-size: 13px;
+    color: var(--text-secondary);
+    z-index: 5;
+}
+
+.command-bar-left {
+    position: relative;
+}
+
+.command-bar-left.popover-open .command-bar-popover {
+    display: block;
+}
+```
+
+**Step 3: Add click-outside dismiss**
+
+Add a small script in `spec_view.html` (can be added to any of the existing `<script>` blocks):
+
+```javascript
+document.addEventListener('click', function(e) {
+    if (!e.target.closest('.command-bar-left')) {
+        document.querySelectorAll('.command-bar-left.popover-open').forEach(function(el) {
+            el.classList.remove('popover-open');
+        });
+    }
+});
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test --all
+```
+
+**Step 5: Visual verification**
+
+At 390px width: tap title, popover appears below with subtitle text. Tap outside, it closes. On desktop, title is not clickable, popover hidden, subtitle visible inline as before.
+
+**Step 6: Commit**
+
+```bash
+git add templates/partials/spec_view.html static/style.css
+git commit -m "feat: add subtitle popover for mobile command bar"
+```
+
+---
+
+### Task 3: Mobile tab switcher for refining mode
+
+On mobile, replace the side-by-side canvas + chat rail with two tabs: the active view name and "Chat". CSS toggles visibility; a small tab bar sits below the view toggles row.
+
+**Files:**
+- Modify: `templates/partials/spec_view.html:96-155` (refining phase block)
+- Modify: `static/style.css` (add mobile tab styles)
+
+**Step 1: Add mobile tab bar markup**
+
+In the refining phase block of `spec_view.html`, add a tab bar between the view-toggles-row and spec-body:
+
+```html
+<div class="mobile-content-tabs">
+    <button class="mobile-tab active" data-target="canvas" onclick="switchMobileTab(this, 'canvas')">Content</button>
+    <button class="mobile-tab" data-target="chat" onclick="switchMobileTab(this, 'chat')">Chat</button>
+</div>
+```
+
+**Step 2: Add tab switcher JS**
+
+Add to the refining phase `<script>` block:
+
+```javascript
+function switchMobileTab(btn, target) {
+    document.querySelectorAll('.mobile-tab').forEach(function(t) { t.classList.remove('active'); });
+    btn.classList.add('active');
+    var body = document.querySelector('.spec-body');
+    if (target === 'chat') {
+        body.classList.add('show-chat');
+    } else {
+        body.classList.remove('show-chat');
+    }
+}
+```
+
+**Step 3: Add mobile tab CSS**
+
+Base styles (hidden on desktop):
+
+```css
+.mobile-content-tabs {
+    display: none;
+}
+```
+
+Inside `@media (max-width: 900px)`:
+
+```css
+.mobile-content-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-card);
+    flex-shrink: 0;
+}
+
+.mobile-tab {
+    flex: 1;
+    padding: 10px;
+    border: none;
+    background: none;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font-body);
+    color: var(--text-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+}
+
+.mobile-tab.active {
+    color: var(--text-primary);
+    border-bottom-color: var(--text-primary);
+}
+
+/* Canvas/chat toggle on mobile */
+.spec-body .canvas {
+    display: flex;
+}
+.spec-body .chat-rail {
+    display: none;
+}
+.spec-body.show-chat .canvas {
+    display: none;
+}
+.spec-body.show-chat .chat-rail {
+    display: flex;
+    width: 100%;
+    border-left: none;
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test --all
+```
+
+**Step 5: Visual verification**
+
+At 390px: two tabs visible below view toggles — "Content" (active, showing document) and "Chat". Tap Chat to see the chat rail full-width. Tap Content to go back. Desktop: tabs hidden, side-by-side layout unchanged.
+
+**Step 6: Commit**
+
+```bash
+git add templates/partials/spec_view.html static/style.css
+git commit -m "feat: add mobile content/chat tab switcher for refining mode"
+```
+
+---
+
+### Task 4: Responsive phase stepper
+
+On mobile, hide connector lines and non-active step labels. Show only step numbers for inactive steps and number + label for the active step.
+
+**Files:**
+- Modify: `static/style.css` (add mobile stepper rules inside media query)
+
+**Step 1: Add mobile stepper CSS**
+
+Inside `@media (max-width: 900px)`:
+
+```css
+.phase-stepper {
+    gap: 0;
+    padding: 8px 16px;
+}
+
+.phase-step-connector {
+    width: 24px;
+}
+
+.phase-step {
+    padding: 4px 8px;
+}
+
+.phase-step-label {
+    display: none;
+}
+
+.phase-step.step-active .phase-step-label {
+    display: inline;
+}
+```
+
+**Step 2: Run tests**
+
+```bash
+cargo test --all
+```
+
+**Step 3: Visual verification**
+
+At 390px: stepper shows `(✓) —— Refine —— (3)` — compact, no overflow. Active step shows label, inactive steps show only the number circle. On desktop, unchanged.
+
+**Step 4: Commit**
+
+```bash
+git add static/style.css
+git commit -m "style: responsive phase stepper — compact labels on mobile"
+```
+
+---
+
+### Task 5: View toggles — show active label
+
+On mobile, keep icons-only for inactive toggles but show the label for the active toggle.
+
+**Files:**
+- Modify: `static/style.css:210-217` (view-toggle-label rules)
+
+**Step 1: Update view toggle label CSS**
+
+Replace the current toggle-label rules:
+
+```css
+.view-toggle-label {
+    display: none;
+}
+@media (min-width: 901px) {
+    .view-toggle-label {
+        display: inline;
+    }
+}
+```
+
+With:
+
+```css
+.view-toggle-label {
+    display: none;
+}
+.view-toggle.active .view-toggle-label {
+    display: inline;
+}
+@media (min-width: 901px) {
+    .view-toggle-label {
+        display: inline;
+    }
+}
+```
+
+This shows the label for the active toggle at all screen sizes, while keeping inactive labels desktop-only.
+
+**Step 2: Run tests**
+
+```bash
+cargo test --all
+```
+
+**Step 3: Visual verification**
+
+At 390px: active toggle shows icon + label (e.g., `[doc-icon Document]`), inactive show icon only. On desktop, all labels visible (unchanged).
+
+**Step 4: Commit**
+
+```bash
+git add static/style.css
+git commit -m "style: show active view toggle label on mobile"
+```

--- a/static/style.css
+++ b/static/style.css
@@ -1824,13 +1824,6 @@ html, body {
   display: block;
 }
 
-.workflow-placeholder {
-    padding: 24px;
-}
-.workflow-summary {
-    margin-top: 24px;
-}
-
 /* Thinking throbber — three bouncing dots */
 .chat-throbber {
     padding: 8px 20px;

--- a/static/style.css
+++ b/static/style.css
@@ -1642,3 +1642,10 @@ html, body {
   display: flex;
   flex-direction: column;
 }
+
+.workflow-placeholder {
+    padding: 24px;
+}
+.workflow-summary {
+    margin-top: 24px;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1582,8 +1582,8 @@ html, body {
   color: #fff;
 }
 
-/* Full-width chat during brainstorming */
-.chat-fullwidth {
+/* Chat panel fills its parent; parent context controls sizing */
+.canvas .chat-panel {
   max-width: 720px;
   margin: 0 auto;
   padding: var(--spacing-md);
@@ -1591,7 +1591,7 @@ html, body {
   flex: 1;
 }
 
-.chat-fullwidth .chat-input-area {
+.canvas .chat-panel .chat-input-area {
   max-width: none;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -216,6 +216,17 @@ html, body {
     }
 }
 
+/* View toggles row — sits below stepper when phase has sub-views */
+.view-toggles-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 20px;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
 /* --- Phase stepper --- */
 .phase-stepper {
     display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -234,6 +234,9 @@ html, body {
 .view-toggle-label {
     display: none;
 }
+.view-toggle.active .view-toggle-label {
+    display: inline;
+}
 @media (min-width: 901px) {
     .view-toggle-label {
         display: inline;
@@ -1836,6 +1839,27 @@ html, body {
         display: flex;
         width: 100%;
         border-left: none;
+    }
+
+    .phase-stepper {
+        gap: 0;
+        padding: 8px 16px;
+    }
+
+    .phase-step-connector {
+        width: 24px;
+    }
+
+    .phase-step {
+        padding: 4px 8px;
+    }
+
+    .phase-step-label {
+        display: none;
+    }
+
+    .phase-step.step-active .phase-step-label {
+        display: inline;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -216,6 +216,97 @@ html, body {
     }
 }
 
+/* --- Phase stepper --- */
+.phase-stepper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    padding: 12px 20px;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.phase-step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font-body);
+    color: var(--text-muted);
+    transition: all 0.2s;
+    white-space: nowrap;
+    position: relative;
+}
+
+.phase-step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    font-size: 12px;
+    font-weight: 600;
+    border: 2px solid var(--border);
+    color: var(--text-muted);
+    background: var(--bg-card);
+    transition: all 0.2s;
+    flex-shrink: 0;
+}
+
+.phase-step-label {
+    transition: color 0.2s;
+}
+
+.phase-step-connector {
+    width: 48px;
+    height: 2px;
+    background: var(--border);
+    flex-shrink: 0;
+    transition: background 0.2s;
+}
+
+.phase-step.step-active {
+    cursor: default;
+    color: var(--text-primary);
+}
+.phase-step.step-active .phase-step-number {
+    background: var(--text-primary);
+    border-color: var(--text-primary);
+    color: var(--bg-card);
+}
+
+.phase-step.step-completed {
+    color: var(--text-primary);
+}
+.phase-step.step-completed:hover {
+    opacity: 0.7;
+}
+.phase-step.step-completed .phase-step-number {
+    background: var(--success, #22c55e);
+    border-color: var(--success, #22c55e);
+    color: #fff;
+}
+
+.phase-step-connector.connector-completed {
+    background: var(--success, #22c55e);
+}
+
+.phase-step.step-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+.phase-step.step-disabled .phase-step-number {
+    border-style: dashed;
+}
+
 /* --- Agent status pill (replaces separate LEDs + controls) --- */
 .agent-pill {
     display: flex;

--- a/static/style.css
+++ b/static/style.css
@@ -1677,29 +1677,6 @@ html, body {
     }
 }
 
-/* Phase badge */
-.phase-badge {
-  display: inline-block;
-  padding: 2px 10px;
-  border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.phase-brainstorming {
-  background: var(--agent-accent);
-  color: #fff;
-}
-.phase-refining {
-  background: var(--accent, #6366f1);
-  color: #fff;
-}
-.phase-complete {
-  background: var(--success, #22c55e);
-  color: #fff;
-}
 
 /* Chat panel fills its parent; parent context controls sizing */
 .canvas .chat-panel {

--- a/static/style.css
+++ b/static/style.css
@@ -1651,6 +1651,12 @@ html, body {
   flex-direction: column;
 }
 
+[data-view="brainstorming"] .spec-body > .canvas.canvas-board {
+  overflow-y: auto;
+  padding: var(--spacing-lg);
+  display: block;
+}
+
 .workflow-placeholder {
     padding: 24px;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1724,3 +1724,9 @@ html, body {
 .chat-option-submit:hover {
     opacity: 0.85;
 }
+.chat-status-repeat {
+    font-size: 10px;
+    color: var(--text-muted);
+    opacity: 0.6;
+    white-space: nowrap;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -164,6 +164,34 @@ html, body {
     max-width: 500px;
     margin: 0 auto;
 }
+.create-spec-form .form-hint {
+    color: var(--text-secondary);
+    margin-bottom: var(--spacing-md);
+    font-size: 0.85rem;
+}
+.create-spec-form .form-label {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+.create-spec-form .form-group {
+    margin-bottom: var(--spacing-md);
+}
+.create-spec-form .form-select {
+    margin-top: 4px;
+    width: 100%;
+    padding: 8px 12px;
+    font-size: 14px;
+    font-family: var(--font-body);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238A8480' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+}
 
 .chat-rail {
     width: var(--chat-rail-width);

--- a/static/style.css
+++ b/static/style.css
@@ -1750,3 +1750,27 @@ html, body {
     70% { opacity: 1; }
     100% { opacity: 0; }
 }
+
+/* Streaming message — raw text while tokens arrive */
+.chat-streaming-msg {
+    padding: 8px 20px;
+}
+.chat-streaming-msg .chat-body {
+    white-space: pre-wrap;
+    font-family: inherit;
+    min-height: 20px;
+}
+
+/* Worker activity status line — "tail -n 1" of agent activity */
+.chat-activity-status {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 20px;
+    font-size: 12px;
+    color: var(--text-muted);
+    opacity: 0.8;
+}
+.chat-activity-status .status-dot {
+    flex-shrink: 0;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -190,8 +190,37 @@ html, body {
     gap: 12px;
     flex-shrink: 0;
 }
-.command-bar-popover {
+/* Title tooltip — visible on hover; on mobile replaces the hidden subtitle */
+.command-bar-title {
+    position: relative;
+}
+.command-bar-tooltip {
     display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    padding: 6px 12px;
+    background: var(--text-primary);
+    color: var(--bg-card);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    border-radius: 6px;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 20;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.command-bar-tooltip::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 20px;
+    border: 5px solid transparent;
+    border-bottom-color: var(--text-primary);
+}
+.command-bar-title:hover .command-bar-tooltip {
+    display: block;
 }
 
 /* --- View toggles (capsule) --- */
@@ -1772,31 +1801,6 @@ html, body {
         display: none;
     }
 
-    .command-bar-title {
-        cursor: pointer;
-    }
-
-    .command-bar-popover {
-        display: none;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        right: 0;
-        padding: 8px 16px;
-        background: var(--bg-card);
-        border-bottom: 1px solid var(--border);
-        font-size: 13px;
-        color: var(--text-secondary);
-        z-index: 5;
-    }
-
-    .command-bar-left {
-        position: relative;
-    }
-
-    .command-bar-left.popover-open .command-bar-popover {
-        display: block;
-    }
 
     /* Mobile content/chat tab switcher */
     .mobile-content-tabs {

--- a/static/style.css
+++ b/static/style.css
@@ -1730,3 +1730,23 @@ html, body {
     opacity: 0.6;
     white-space: nowrap;
 }
+
+/* Export button loading indicator */
+.btn-export.htmx-request {
+    opacity: 0.5;
+    pointer-events: none;
+}
+/* Regen confirmation flash */
+.regen-status {
+    font-size: 12px;
+    color: var(--success);
+    font-weight: 500;
+}
+.regen-confirm {
+    animation: regenFlash 3s ease-out forwards;
+}
+@keyframes regenFlash {
+    0% { opacity: 1; }
+    70% { opacity: 1; }
+    100% { opacity: 0; }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -57,6 +57,31 @@
     --font-body: 'DM Sans', system-ui, sans-serif;
 }
 
+/* --- Shared tooltip --- */
+.tooltip {
+    display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    padding: 6px 12px;
+    background: var(--text-primary);
+    color: var(--bg-card);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    border-radius: 6px;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 20;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.tooltip::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    border: 5px solid transparent;
+    border-bottom-color: var(--text-primary);
+}
+
 html, body {
     height: 100%;
     font-family: var(--font-body);
@@ -154,6 +179,7 @@ html, body {
     background: var(--bg-card);
     border-bottom: 1px solid var(--border);
     flex-shrink: 0;
+    position: relative;
 }
 .command-bar-left {
     flex: 1;
@@ -190,36 +216,15 @@ html, body {
     gap: 12px;
     flex-shrink: 0;
 }
-/* Title tooltip — visible on hover; on mobile replaces the hidden subtitle */
-.command-bar-title {
-    position: relative;
-}
+/* Title tooltip — left-aligned, shown when hovering the title */
 .command-bar-tooltip {
-    display: none;
-    position: absolute;
-    top: calc(100% + 8px);
-    left: 0;
-    padding: 6px 12px;
-    background: var(--text-primary);
-    color: var(--bg-card);
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 1.4;
-    border-radius: 6px;
-    white-space: nowrap;
-    pointer-events: none;
-    z-index: 20;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    left: 20px;
+    top: calc(100% + 4px);
 }
 .command-bar-tooltip::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
     left: 20px;
-    border: 5px solid transparent;
-    border-bottom-color: var(--text-primary);
 }
-.command-bar-title:hover .command-bar-tooltip {
+.command-bar-left:hover ~ .command-bar-tooltip {
     display: block;
 }
 
@@ -373,35 +378,16 @@ html, body {
 .phase-step.step-disabled .phase-step-number {
     border-style: dashed;
 }
-/* Step tooltip */
+/* Step tooltip — centered under the step */
 .phase-step-tooltip {
-    display: none;
-    position: absolute;
-    top: calc(100% + 8px);
     left: 50%;
     transform: translateX(-50%);
-    padding: 6px 12px;
-    background: var(--text-primary);
-    color: var(--bg-card);
-    font-size: 12px;
-    font-weight: 400;
-    line-height: 1.4;
-    border-radius: 6px;
-    white-space: nowrap;
-    pointer-events: none;
-    z-index: 20;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 .phase-step-tooltip::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    border: 5px solid transparent;
-    border-bottom-color: var(--text-primary);
 }
-.phase-step:hover .phase-step-tooltip {
+.phase-step:hover .tooltip {
     display: block;
 }
 
@@ -1797,6 +1783,7 @@ html, body {
         grid-template-columns: 1fr;
     }
 
+    .command-bar-chevron,
     .command-bar-subtitle {
         display: none;
     }

--- a/static/style.css
+++ b/static/style.css
@@ -1611,6 +1611,29 @@ html, body {
   flex: 1;
 }
 
+/* Agents-offline: dim entire interface when agents aren't running */
+.spec-compositor.agents-offline .spec-body {
+    opacity: 0.5;
+    pointer-events: none;
+}
+.spec-compositor.agents-offline .agents-offline-banner {
+    pointer-events: auto;
+    opacity: 1;
+}
+.agents-offline-banner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: var(--bg-secondary);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+.agents-offline-banner .btn {
+    white-space: nowrap;
+}
+
 [data-view="brainstorming"] .spec-body > .canvas {
   flex: 1;
   min-width: 300px;

--- a/static/style.css
+++ b/static/style.css
@@ -1709,6 +1709,11 @@ html, body {
     overflow: hidden;
 }
 
+/* Mobile content/chat tab bar — hidden on desktop */
+.mobile-content-tabs {
+    display: none;
+}
+
 /* --- Responsive: stack on mobile --- */
 @media (max-width: 900px) {
     .app-layout {
@@ -1788,6 +1793,49 @@ html, body {
 
     .command-bar-left.popover-open .command-bar-popover {
         display: block;
+    }
+
+    /* Mobile content/chat tab switcher */
+    .mobile-content-tabs {
+        display: flex;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg-card);
+        flex-shrink: 0;
+    }
+
+    .mobile-tab {
+        flex: 1;
+        padding: 10px;
+        border: none;
+        background: none;
+        font-size: 13px;
+        font-weight: 500;
+        font-family: var(--font-body);
+        color: var(--text-muted);
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+        transition: all 0.2s;
+    }
+
+    .mobile-tab.active {
+        color: var(--text-primary);
+        border-bottom-color: var(--text-primary);
+    }
+
+    /* Canvas/chat toggle on mobile */
+    .spec-body .canvas {
+        display: flex;
+    }
+    .spec-body .chat-rail {
+        display: none;
+    }
+    .spec-body.show-chat .canvas {
+        display: none;
+    }
+    .spec-body.show-chat .chat-rail {
+        display: flex;
+        width: 100%;
+        border-left: none;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1681,3 +1681,40 @@ html, body {
     0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
     40% { opacity: 1; transform: scale(1); }
 }
+
+/* Multi-select checkboxes in question cards */
+.chat-option-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    border-radius: var(--radius-xl);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 12px 16px;
+    font-size: 14px;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.chat-option-checkbox:hover {
+    border-color: var(--text-muted);
+}
+.chat-option-checkbox:has(input:checked) {
+    border-color: var(--text-primary);
+    background: var(--bg-secondary);
+}
+.chat-option-checkbox input[type="checkbox"] {
+    accent-color: var(--text-primary);
+    width: 16px;
+    height: 16px;
+}
+.chat-option-submit {
+    background: var(--text-primary);
+    color: var(--bg-card);
+    text-align: center;
+    font-weight: 600;
+}
+.chat-option-submit:hover {
+    opacity: 0.85;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -84,6 +84,27 @@ html, body {
     overflow: hidden;
 }
 
+/* Hamburger menu — hidden on desktop, shown on mobile */
+.hamburger {
+    display: none;
+    position: fixed;
+    top: 12px;
+    left: 12px;
+    z-index: 51;
+    border: none;
+    background: var(--bg-card);
+    border-radius: 8px;
+    padding: 8px;
+    cursor: pointer;
+    color: var(--text-primary);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Backdrop for mobile nav drawer */
+.nav-backdrop {
+    display: none;
+}
+
 .workspace {
     display: flex;
     flex-direction: column;
@@ -367,13 +388,6 @@ html, body {
     background: var(--text-primary);
     color: var(--bg-primary);
 }
-.agent-pill-paused {
-    background: var(--bg-secondary);
-    color: var(--text-muted);
-}
-.agent-pill-paused:hover {
-    color: var(--text-primary);
-}
 .agent-pill-stopped {
     background: var(--agent-accent, #222);
     color: #fff;
@@ -388,10 +402,6 @@ html, body {
 }
 .agent-pill-running .agent-pill-dot {
     background: #34D399;
-}
-.agent-pill-paused .agent-pill-dot {
-    background: var(--text-muted);
-    opacity: 0.4;
 }
 .agent-pill-stopped .agent-pill-dot {
     background: #fff;
@@ -1700,23 +1710,51 @@ html, body {
 @media (max-width: 900px) {
     .app-layout {
         grid-template-columns: 1fr;
-        grid-template-rows: auto 1fr;
+        grid-template-rows: 1fr;
+    }
+
+    .hamburger {
+        display: flex;
     }
 
     .nav-rail {
-        border-right: none;
-        border-bottom: 1px solid var(--border-subtle);
-        max-height: 200px;
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        width: 80vw;
+        max-width: 320px;
+        z-index: 50;
+        transform: translateX(-100%);
+        transition: transform 0.25s ease;
+        border-right: 1px solid var(--border);
+        border-bottom: none;
+        max-height: none;
+    }
+
+    .app-layout.nav-open .nav-rail {
+        transform: translateX(0);
+    }
+
+    .nav-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        z-index: 49;
+        background: rgba(0, 0, 0, 0.3);
+    }
+
+    .app-layout.nav-open .nav-backdrop {
+        display: block;
+    }
+
+    /* Offset command bar for hamburger button */
+    .command-bar {
+        padding-left: 52px;
     }
 
     .board {
         grid-template-columns: 1fr;
-    }
-
-    .command-bar {
-        flex-wrap: wrap;
-        height: auto;
-        padding: var(--spacing-sm) var(--spacing-md);
     }
 
     .command-bar-subtitle {

--- a/static/style.css
+++ b/static/style.css
@@ -190,6 +190,9 @@ html, body {
     gap: 12px;
     flex-shrink: 0;
 }
+.command-bar-popover {
+    display: none;
+}
 
 /* --- View toggles (capsule) --- */
 .view-toggles-capsule {
@@ -1759,6 +1762,32 @@ html, body {
 
     .command-bar-subtitle {
         display: none;
+    }
+
+    .command-bar-title {
+        cursor: pointer;
+    }
+
+    .command-bar-popover {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        padding: 8px 16px;
+        background: var(--bg-card);
+        border-bottom: 1px solid var(--border);
+        font-size: 13px;
+        color: var(--text-secondary);
+        z-index: 5;
+    }
+
+    .command-bar-left {
+        position: relative;
+    }
+
+    .command-bar-left.popover-open .command-bar-popover {
+        display: block;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -436,18 +436,6 @@ html, body {
     height: 100%;
     background: var(--bg-card);
 }
-.chat-panel-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px 20px;
-    border-bottom: 1px solid var(--border);
-}
-.chat-panel-title {
-    font-size: 15px;
-    font-weight: 500;
-    color: var(--text-primary);
-}
 
 /* --- Rail sections --- */
 .rail-header {

--- a/static/style.css
+++ b/static/style.css
@@ -92,6 +92,7 @@ html, body {
 }
 
 .spec-compositor {
+    position: relative;
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -233,14 +234,19 @@ html, body {
     background: var(--text-primary);
     color: var(--bg-primary);
 }
-.agent-pill-paused,
-.agent-pill-stopped {
+.agent-pill-paused {
     background: var(--bg-secondary);
     color: var(--text-muted);
 }
-.agent-pill-paused:hover,
-.agent-pill-stopped:hover {
+.agent-pill-paused:hover {
     color: var(--text-primary);
+}
+.agent-pill-stopped {
+    background: var(--agent-accent, #222);
+    color: #fff;
+}
+.agent-pill-stopped:hover {
+    opacity: 0.85;
 }
 .agent-pill-dot {
     width: 8px;
@@ -250,10 +256,13 @@ html, body {
 .agent-pill-running .agent-pill-dot {
     background: #34D399;
 }
-.agent-pill-paused .agent-pill-dot,
-.agent-pill-stopped .agent-pill-dot {
+.agent-pill-paused .agent-pill-dot {
     background: var(--text-muted);
     opacity: 0.4;
+}
+.agent-pill-stopped .agent-pill-dot {
+    background: #fff;
+    opacity: 0.6;
 }
 
 /* --- Chat panel (right rail) --- */
@@ -1619,27 +1628,59 @@ html, body {
   flex: 1;
 }
 
-/* Agents-offline: dim entire interface when agents aren't running */
+/* Agents-offline: dim when agents aren't running, but still interactive */
 .spec-compositor.agents-offline .spec-body {
     opacity: 0.5;
-    pointer-events: none;
-}
-.spec-compositor.agents-offline .agents-offline-banner {
-    pointer-events: auto;
-    opacity: 1;
 }
 .agents-offline-banner {
+    display: none;
+}
+.spec-compositor.agents-offline .agents-offline-banner {
     display: flex;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 10;
+    flex-direction: column;
     align-items: center;
     gap: 12px;
-    padding: 10px 16px;
-    background: var(--bg-secondary);
-    border-bottom: 1px solid var(--border);
+    padding: 24px 32px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
     font-size: 0.875rem;
     color: var(--text-muted);
+    pointer-events: auto;
 }
-.agents-offline-banner .btn {
+.agents-offline-banner .btn-start-agents {
     white-space: nowrap;
+    padding: 8px 24px;
+    background: var(--agent-accent, #222);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
+}
+.agents-offline-banner .btn-start-agents:hover {
+    opacity: 0.85;
+}
+.agents-offline-dismiss {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.1rem;
+    line-height: 1;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0 4px;
+}
+.agents-offline-dismiss:hover {
+    color: var(--text-primary);
 }
 
 [data-view="brainstorming"] .spec-body > .canvas {

--- a/static/style.css
+++ b/static/style.css
@@ -264,7 +264,7 @@ html, body {
 .phase-step-label {
     transition: color 0.2s;
 }
-
+/* Connector line between steps */
 .phase-step-connector {
     width: 48px;
     height: 2px;
@@ -272,7 +272,7 @@ html, body {
     flex-shrink: 0;
     transition: background 0.2s;
 }
-
+/* Active step */
 .phase-step.step-active {
     cursor: default;
     color: var(--text-primary);
@@ -282,7 +282,7 @@ html, body {
     border-color: var(--text-primary);
     color: var(--bg-card);
 }
-
+/* Completed step */
 .phase-step.step-completed {
     color: var(--text-primary);
 }
@@ -294,11 +294,11 @@ html, body {
     border-color: var(--success, #22c55e);
     color: #fff;
 }
-
+/* Completed connector */
 .phase-step-connector.connector-completed {
     background: var(--success, #22c55e);
 }
-
+/* Disabled/upcoming step */
 .phase-step.step-disabled {
     cursor: not-allowed;
     opacity: 0.5;

--- a/static/style.css
+++ b/static/style.css
@@ -1811,6 +1811,12 @@ html, body {
     .command-bar-subtitle {
         display: none;
     }
+
+    /* Native select popover mis-anchors on mobile Safari/macOS — hide optional field */
+    .create-spec-form .form-group:has(.form-select) {
+        display: none;
+    }
+
     /* Brainstorming canvas: remove min-width that causes horizontal overflow */
     [data-view="brainstorming"] .spec-body > .canvas {
         min-width: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -1581,6 +1581,14 @@ html, body {
   background: var(--agent-accent);
   color: #fff;
 }
+.phase-refining {
+  background: var(--accent, #6366f1);
+  color: #fff;
+}
+.phase-complete {
+  background: var(--success, #22c55e);
+  color: #fff;
+}
 
 /* Chat panel fills its parent; parent context controls sizing */
 .canvas .chat-panel {

--- a/static/style.css
+++ b/static/style.css
@@ -1811,11 +1811,6 @@ html, body {
     .command-bar-subtitle {
         display: none;
     }
-
-    .format-hint-group {
-        display: none;
-    }
-
     /* Brainstorming canvas: remove min-width that causes horizontal overflow */
     [data-view="brainstorming"] .spec-body > .canvas {
         min-width: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -1282,6 +1282,15 @@ html, body {
     display: flex;
     flex-direction: column;
     padding: 12px 0;
+    min-height: 0;
+}
+
+/* Question card wrapper — shrink so it doesn't steal all space from the feed */
+.chat-question-wrap {
+    flex: 0 1 auto;
+    min-height: 0;
+    max-height: 50%;
+    overflow-y: auto;
 }
 
 /* Hide general chat input when agent is asking a question */
@@ -1421,9 +1430,7 @@ html, body {
     border-radius: var(--radius-xl);
     background: var(--bg-secondary);
     padding: 20px;
-    flex-shrink: 0;
     overflow-y: auto;
-    max-height: 40%;
 }
 
 .chat-question-body {
@@ -1473,6 +1480,15 @@ html, body {
     display: flex;
     flex-direction: column;
     gap: 8px;
+}
+.chat-else-back {
+    font-size: 12px;
+    color: var(--text-muted);
+    text-decoration: none;
+    align-self: flex-start;
+}
+.chat-else-back:hover {
+    color: var(--text-primary);
 }
 
 /* Reuse .chat-input-row inside question cards */

--- a/static/style.css
+++ b/static/style.css
@@ -1737,6 +1737,8 @@ html, body {
     .app-layout {
         grid-template-columns: 1fr;
         grid-template-rows: 1fr;
+        max-width: 100vw;
+        overflow-x: hidden;
     }
 
     .hamburger {
@@ -1786,6 +1788,11 @@ html, body {
     .command-bar-chevron,
     .command-bar-subtitle {
         display: none;
+    }
+
+    /* Brainstorming canvas: remove min-width that causes horizontal overflow */
+    [data-view="brainstorming"] .spec-body > .canvas {
+        min-width: 0;
     }
 
 
@@ -1857,6 +1864,7 @@ html, body {
 
 /* Chat panel fills its parent; parent context controls sizing */
 .canvas .chat-panel {
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: var(--spacing-md);

--- a/static/style.css
+++ b/static/style.css
@@ -159,6 +159,12 @@ html, body {
     padding: var(--spacing-lg);
 }
 
+.create-spec-form {
+    padding: var(--spacing-lg);
+    max-width: 500px;
+    margin: 0 auto;
+}
+
 .chat-rail {
     width: var(--chat-rail-width);
     flex-shrink: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -1657,3 +1657,27 @@ html, body {
 .workflow-summary {
     margin-top: 24px;
 }
+
+/* Thinking throbber — three bouncing dots */
+.chat-throbber {
+    padding: 8px 20px;
+}
+.thinking-dots {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+    height: 20px;
+}
+.thinking-dots span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    animation: throbberBounce 1.4s ease-in-out infinite;
+}
+.thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+.thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes throbberBounce {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -317,6 +317,37 @@ html, body {
 .phase-step.step-disabled .phase-step-number {
     border-style: dashed;
 }
+/* Step tooltip */
+.phase-step-tooltip {
+    display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 6px 12px;
+    background: var(--text-primary);
+    color: var(--bg-card);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    border-radius: 6px;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 20;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+.phase-step-tooltip::before {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-bottom-color: var(--text-primary);
+}
+.phase-step:hover .phase-step-tooltip {
+    display: block;
+}
 
 /* --- Agent status pill (replaces separate LEDs + controls) --- */
 .agent-pill {

--- a/static/style.css
+++ b/static/style.css
@@ -1733,6 +1733,11 @@ html, body {
         display: flex;
     }
 
+    /* Clear space for the fixed hamburger button on pages without a command bar */
+    .workspace > :first-child:not(.spec-compositor) {
+        padding-top: 56px;
+    }
+
     .nav-rail {
         position: fixed;
         top: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -1812,6 +1812,10 @@ html, body {
         display: none;
     }
 
+    .format-hint-group {
+        display: none;
+    }
+
     /* Brainstorming canvas: remove min-width that causes horizontal overflow */
     [data-view="brainstorming"] .spec-body > .canvas {
         min-width: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -186,11 +186,6 @@ html, body {
     border-radius: var(--radius);
     background: var(--bg-card);
     color: var(--text-primary);
-    appearance: none;
-    -webkit-appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238A8480' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
 }
 
 .chat-rail {

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,9 +33,9 @@
         <div class="workspace" id="workspace">{% block workspace %}{% endblock %}</div>
     </div>
     <script>
-        // Close mobile nav drawer when a link inside it is clicked
+        // Close mobile nav drawer when a link or button inside it is clicked
         document.querySelector('.nav-rail').addEventListener('click', function(e) {
-            if (e.target.closest('a')) {
+            if (e.target.closest('a') || e.target.closest('button')) {
                 document.querySelector('.app-layout').classList.remove('nav-open');
             }
         });

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,11 @@
 </head>
 <body>
     <div class="app-layout">
+        <button class="hamburger" onclick="document.querySelector('.app-layout').classList.toggle('nav-open')" aria-label="Toggle navigation">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+        </button>
         <nav class="nav-rail">{% block nav %}{% endblock %}</nav>
+        <div class="nav-backdrop" onclick="document.querySelector('.app-layout').classList.remove('nav-open')"></div>
         <div class="workspace" id="workspace">{% block workspace %}{% endblock %}</div>
     </div>
     {% block scripts %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,14 @@
         <div class="nav-backdrop" onclick="document.querySelector('.app-layout').classList.remove('nav-open')"></div>
         <div class="workspace" id="workspace">{% block workspace %}{% endblock %}</div>
     </div>
+    <script>
+        // Close mobile nav drawer when a link inside it is clicked
+        document.querySelector('.nav-rail').addEventListener('click', function(e) {
+            if (e.target.closest('a')) {
+                document.querySelector('.app-layout').classList.remove('nav-open');
+            }
+        });
+    </script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 <div class="rail-header">
     <span>Your specs</span>
 </div>
-<div class="spec-list" id="spec-list" hx-get="/web/specs" hx-trigger="load" hx-swap="innerHTML">
+<div class="spec-list" id="spec-list" hx-get="/web/specs" hx-trigger="load, every 30s" hx-swap="innerHTML">
     <p class="loading">Loading specs...</p>
 </div>
 <div id="provider-status" hx-get="/web/provider-status" hx-trigger="load" hx-swap="innerHTML">

--- a/templates/partials/activity_transcript.html
+++ b/templates/partials/activity_transcript.html
@@ -14,6 +14,9 @@
             <span class="activity-status-badge">{{ entry.sender_label }}</span>
             <span class="activity-status-text">{{ entry.content }}</span>
             <span class="activity-status-time">{{ entry.timestamp }}</span>
+            {% if entry.repeat_count > 1 %}
+            <span class="chat-status-repeat">(&times;{{ entry.repeat_count }})</span>
+            {% endif %}
         </div>
         {% else %}
         <div class="message {% if entry.is_human %}message-human{% else %}message-agent{% endif %}">

--- a/templates/partials/agent_status.html
+++ b/templates/partials/agent_status.html
@@ -1,5 +1,5 @@
 {# ABOUTME: Agent status pill button for the command bar. #}
-{# ABOUTME: Single toggle: dark pill when running (with green dot), light when paused/stopped. #}
+{# ABOUTME: Two-state toggle: running (green dot, click to stop) or off (click to start). #}
 
 <div id="agent-status">
     {% if running %}
@@ -10,17 +10,9 @@
         <span class="agent-pill-dot"></span>
         Agents active
     </button>
-    {% else if started %}
-    <button class="agent-pill agent-pill-paused"
-            hx-post="/web/specs/{{ spec_id }}/agents/resume"
-            hx-target="#agent-status"
-            hx-swap="outerHTML">
-        <span class="agent-pill-dot"></span>
-        Agents paused
-    </button>
     {% else %}
     <button class="agent-pill agent-pill-stopped"
-            hx-post="/web/specs/{{ spec_id }}/agents/start"
+            hx-post="/web/specs/{{ spec_id }}/agents/{% if started %}resume{% else %}start{% endif %}"
             hx-target="#agent-status"
             hx-swap="outerHTML">
         <span class="agent-pill-dot"></span>

--- a/templates/partials/agent_status.html
+++ b/templates/partials/agent_status.html
@@ -28,3 +28,21 @@
     </button>
     {% endif %}
 </div>
+
+<script>
+(function() {
+    var running = {% if running %}true{% else %}false{% endif %};
+    var compositor = document.querySelector('.spec-compositor');
+    var banner = document.getElementById('agents-offline-banner');
+    if (compositor) {
+        if (running) {
+            compositor.classList.remove('agents-offline');
+        } else {
+            compositor.classList.add('agents-offline');
+        }
+    }
+    if (banner) {
+        banner.style.display = running ? 'none' : 'flex';
+    }
+})();
+</script>

--- a/templates/partials/agent_status.html
+++ b/templates/partials/agent_status.html
@@ -33,16 +33,12 @@
 (function() {
     var running = {% if running %}true{% else %}false{% endif %};
     var compositor = document.querySelector('.spec-compositor');
-    var banner = document.getElementById('agents-offline-banner');
     if (compositor) {
         if (running) {
             compositor.classList.remove('agents-offline');
         } else {
             compositor.classList.add('agents-offline');
         }
-    }
-    if (banner) {
-        banner.style.display = running ? 'none' : 'flex';
     }
 })();
 </script>

--- a/templates/partials/artifacts.html
+++ b/templates/partials/artifacts.html
@@ -15,7 +15,7 @@
     <div class="artifact-content" id="artifact-markdown">
         <div class="artifact-toolbar">
             <button class="btn btn-sm btn-copy" data-copy="markdown-source">Copy</button>
-            <a href="/web/specs/{{ spec_id }}/export/markdown" download="spec.md" class="btn btn-sm btn-download">Download</a>
+            <a href="/web/specs/{{ spec_id }}/export/markdown" download="{{ title_slug }}-spec.md" class="btn btn-sm btn-download">Download</a>
         </div>
         <pre class="artifact-source" id="markdown-source"><code>{{ markdown_content }}</code></pre>
     </div>
@@ -23,7 +23,7 @@
     <div class="artifact-content hidden" id="artifact-yaml">
         <div class="artifact-toolbar">
             <button class="btn btn-sm btn-copy" data-copy="yaml-source">Copy</button>
-            <a href="/web/specs/{{ spec_id }}/export/yaml" download="spec.yaml" class="btn btn-sm btn-download">Download</a>
+            <a href="/web/specs/{{ spec_id }}/export/yaml" download="{{ title_slug }}-spec.yaml" class="btn btn-sm btn-download">Download</a>
         </div>
         <pre class="artifact-source" id="yaml-source"><code>{{ yaml_content }}</code></pre>
     </div>
@@ -31,7 +31,7 @@
     <div class="artifact-content hidden" id="artifact-dot">
         <div class="artifact-toolbar">
             <button class="btn btn-sm btn-copy" data-copy="dot-source">Copy</button>
-            <a href="/web/specs/{{ spec_id }}/export/dot" download="spec.dot" class="btn btn-sm btn-download">Download</a>
+            <a href="/web/specs/{{ spec_id }}/export/dot" download="{{ title_slug }}-spec.dot" class="btn btn-sm btn-download">Download</a>
         </div>
         <pre class="artifact-source" id="dot-source"><code>{{ dot_content }}</code></pre>
     </div>

--- a/templates/partials/board.html
+++ b/templates/partials/board.html
@@ -2,7 +2,7 @@
     {% for lane in lanes %}
     <div class="lane">
         <div class="lane-header">
-            <h3>{{ lane.name }}</h3>
+            <h3 title="{% if lane.name == "Ideas" %}Raw ideas from brainstorming — unstructured thoughts and suggestions.{% else if lane.name == "Plan" %}Items being refined into actionable tasks for the spec.{% else if lane.name == "Spec" %}Finalized spec items that define the implementation.{% else %}{{ lane.name }}{% endif %}">{{ lane.name }}</h3>
             <span class="lane-count">{{ lane.cards.len() }}</span>
         </div>
         <div class="lane-cards" data-lane="{{ lane.name }}">

--- a/templates/partials/chat_feed.html
+++ b/templates/partials/chat_feed.html
@@ -1,0 +1,64 @@
+{# ABOUTME: Message feed portion of chat transcript, rendered independently for HTMX partial refresh. #}
+{# ABOUTME: Refreshes only on transcript_appended SSE events, leaving question card untouched. #}
+
+<div class="chat-messages"
+     id="{{ container_id }}-feed"
+     hx-trigger="sse:transcript_appended"
+     hx-get="/web/specs/{{ spec_id }}/activity/transcript?container_id={{ container_id }}&amp;part=feed"
+     hx-target="#{{ container_id }}-feed"
+     hx-swap="outerHTML">
+    {% for entry in transcript %}
+    {% if entry.is_step %}
+    <div class="chat-status-line">
+        <span class="status-dot dot-{{ entry.role_class }}"></span>
+        <span class="chat-status-body">{{ entry.sender_label }} {{ entry.content }}</span>
+        <span class="chat-status-time">{{ entry.timestamp }}</span>
+        {% if entry.repeat_count > 1 %}
+        <span class="chat-status-repeat">(&times;{{ entry.repeat_count }})</span>
+        {% endif %}
+    </div>
+    {% else %}
+    <div class="chat-message {% if entry.is_continuation %}chat-continuation{% endif %}">
+        {% if !entry.is_continuation %}
+        <div class="chat-message-header">
+            <div class="chat-avatar avatar-{{ entry.role_class }}">{{ entry.initial }}</div>
+            <span class="chat-sender">{{ entry.sender_label }}</span>
+            <span class="chat-time">{{ entry.timestamp }}</span>
+        </div>
+        {% endif %}
+        <div class="chat-body">{{ entry.content_html|safe }}</div>
+    </div>
+    {% endif %}
+    {% endfor %}
+    <div id="{{ container_id }}-throbber" class="chat-throbber" style="display:none;">
+        <div class="chat-message">
+            <div class="chat-message-header">
+                <div class="chat-avatar avatar-manager">O</div>
+                <span class="chat-sender">Orchestrator</span>
+            </div>
+            <div class="chat-body">
+                <span class="thinking-dots"><span></span><span></span><span></span></span>
+            </div>
+        </div>
+    </div>
+    <div id="{{ container_id }}-streaming" class="chat-streaming-msg" style="display:none;">
+        <div class="chat-message">
+            <div class="chat-message-header">
+                <div class="chat-avatar avatar-manager">O</div>
+                <span class="chat-sender">Orchestrator</span>
+            </div>
+            <div class="chat-body" id="{{ container_id }}-streaming-body"></div>
+        </div>
+    </div>
+    <div id="{{ container_id }}-activity" class="chat-activity-status" style="display:none;">
+        <span class="status-dot dot-agent"></span>
+        <span id="{{ container_id }}-activity-text"></span>
+    </div>
+    {% if transcript.is_empty() %}
+    <div class="chat-empty">
+        <div class="chat-empty-icon">&#128172;</div>
+        <p class="chat-empty-title">No messages yet</p>
+        <p class="chat-empty-hint">Type below to start a conversation with the agents.</p>
+    </div>
+    {% endif %}
+</div>

--- a/templates/partials/chat_panel.html
+++ b/templates/partials/chat_panel.html
@@ -2,9 +2,6 @@
 {# ABOUTME: Message list with avatars, question cards, and textarea input. SSE provided by parent. #}
 
 <div class="chat-panel">
-    <div class="chat-panel-header">
-        <span class="chat-panel-title">Chat</span>
-    </div>
     {% include "partials/chat_transcript.html" %}
 
     <div class="chat-input-area">

--- a/templates/partials/chat_panel.html
+++ b/templates/partials/chat_panel.html
@@ -1,7 +1,7 @@
 {# ABOUTME: Chat panel for the right rail of the spec compositor. #}
 {# ABOUTME: Message list with avatars, question cards, and textarea input. SSE provided by parent. #}
 
-<div class="chat-panel{% if is_fullwidth %} chat-fullwidth{% endif %}">
+<div class="chat-panel">
     <div class="chat-panel-header">
         <span class="chat-panel-title">Chat</span>
     </div>

--- a/templates/partials/chat_question.html
+++ b/templates/partials/chat_question.html
@@ -1,0 +1,96 @@
+{# ABOUTME: Question card portion of chat transcript, rendered independently for HTMX partial refresh. #}
+{# ABOUTME: Refreshes on question_asked/question_answered SSE events without touching the message feed. #}
+
+<div id="{{ container_id }}-question"
+     class="chat-question-wrap"
+     hx-trigger="sse:question_asked, sse:question_answered"
+     hx-get="/web/specs/{{ spec_id }}/activity/transcript?container_id={{ container_id }}&amp;part=question"
+     hx-target="#{{ container_id }}-question"
+     hx-swap="outerHTML">
+    {% match pending_question %}
+    {% when Some with (q) %}
+    <div class="chat-question-card">
+        <div class="chat-message-header">
+            <div class="chat-avatar avatar-question">?</div>
+            <span class="chat-sender">Quick decision</span>
+        </div>
+        {% match q %}
+        {% when QuestionData::Boolean { question_id, question, default } %}
+        <div class="chat-question-body">{{ question|safe }}</div>
+        <form hx-post="/web/specs/{{ spec_id }}/answer"
+              hx-target="#{{ container_id }}-question"
+              hx-swap="outerHTML"
+              autocomplete="off"
+              class="chat-question-options">
+            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
+            <div class="chat-options-set">
+                <button type="submit" name="answer" value="Yes" class="chat-option-btn">Yes</button>
+                <button type="submit" name="answer" value="No" class="chat-option-btn">No</button>
+                <button type="button" class="chat-option-btn chat-option-else" onclick="toggleElse(this, true)">Something else&hellip;</button>
+            </div>
+            <div class="chat-else-expand" style="display:none;">
+                <div class="chat-input-row">
+                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore></textarea>
+                    <button type="submit" class="btn btn-send" title="Send">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                    </button>
+                </div>
+                <a href="#" class="chat-else-back" onclick="toggleElse(this, false); return false;">&lsaquo; options</a>
+            </div>
+        </form>
+
+        {% when QuestionData::MultipleChoice { question_id, question, choices, allow_multi } %}
+        <div class="chat-question-body">{{ question|safe }}</div>
+        <form hx-post="/web/specs/{{ spec_id }}/answer"
+              hx-target="#{{ container_id }}-question"
+              hx-swap="outerHTML"
+              autocomplete="off"
+              class="chat-question-options">
+            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
+            <div class="chat-options-set">
+                {% if allow_multi %}
+                {% for choice in choices %}
+                <label class="chat-option-checkbox">
+                    <input type="checkbox" name="answer" value="{{ choice }}">
+                    <span>{{ choice }}</span>
+                </label>
+                {% endfor %}
+                <button type="submit" class="chat-option-btn chat-option-submit" onclick="var f=this.closest('form'); var checked=f.querySelectorAll('input[name=answer]:checked'); if(checked.length===0){event.preventDefault(); return;} var vals=[]; checked.forEach(function(c){vals.push(c.value);}); var h=document.createElement('input'); h.type='hidden'; h.name='answer'; h.value=vals.join(', '); f.appendChild(h); checked.forEach(function(c){c.disabled=true;});">Submit</button>
+                {% else %}
+                {% for choice in choices %}
+                <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
+                {% endfor %}
+                {% endif %}
+                <button type="button" class="chat-option-btn chat-option-else" onclick="toggleElse(this, true)">Something else&hellip;</button>
+            </div>
+            <div class="chat-else-expand" style="display:none;">
+                <div class="chat-input-row">
+                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore></textarea>
+                    <button type="submit" class="btn btn-send" title="Send">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                    </button>
+                </div>
+                <a href="#" class="chat-else-back" onclick="toggleElse(this, false); return false;">&lsaquo; options</a>
+            </div>
+        </form>
+
+        {% when QuestionData::Freeform { question_id, question, placeholder } %}
+        <div class="chat-question-body">{{ question|safe }}</div>
+        <form hx-post="/web/specs/{{ spec_id }}/answer"
+              hx-target="#{{ container_id }}-question"
+              hx-swap="outerHTML"
+              autocomplete="off"
+              class="chat-question-options">
+            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
+            <div class="chat-input-row">
+                <textarea name="answer" placeholder="{{ placeholder }}" rows="1" data-1p-ignore required></textarea>
+                <button type="submit" class="btn btn-send" title="Send">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                </button>
+            </div>
+        </form>
+        {% endmatch %}
+    </div>
+    {% when None %}
+    {% endmatch %}
+</div>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -55,10 +55,10 @@
             <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
             <button type="submit" name="answer" value="Yes" class="chat-option-btn">Yes</button>
             <button type="submit" name="answer" value="No" class="chat-option-btn">No</button>
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer';">Something else&hellip;</button>
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore required></textarea>
+                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore required></textarea>
                     <button type="submit" class="btn btn-send" title="Send">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                     </button>
@@ -77,10 +77,10 @@
             {% for choice in choices %}
             <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
             {% endfor %}
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer';">Something else&hellip;</button>
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="2" data-1p-ignore required></textarea>
+                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore required></textarea>
                     <button type="submit" class="btn btn-send" title="Send">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                     </button>
@@ -97,7 +97,7 @@
               class="chat-question-options">
             <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
             <div class="chat-input-row">
-                <textarea name="answer" placeholder="{{ placeholder }}" rows="2" data-1p-ignore required></textarea>
+                <textarea name="answer" placeholder="{{ placeholder }}" rows="1" data-1p-ignore required></textarea>
                 <button type="submit" class="btn btn-send" title="Send">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                 </button>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -14,6 +14,9 @@
             <span class="status-dot dot-{{ entry.role_class }}"></span>
             <span class="chat-status-body">{{ entry.sender_label }} {{ entry.content }}</span>
             <span class="chat-status-time">{{ entry.timestamp }}</span>
+            {% if entry.repeat_count > 1 %}
+            <span class="chat-status-repeat">(&times;{{ entry.repeat_count }})</span>
+            {% endif %}
         </div>
         {% else %}
         <div class="chat-message {% if entry.is_continuation %}chat-continuation{% endif %}">

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -85,10 +85,20 @@
               autocomplete="off"
               class="chat-question-options">
             <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
+            {% if allow_multi %}
+            {% for choice in choices %}
+            <label class="chat-option-checkbox">
+                <input type="checkbox" name="answer" value="{{ choice }}">
+                <span>{{ choice }}</span>
+            </label>
+            {% endfor %}
+            <button type="submit" class="chat-option-btn chat-option-submit" onclick="var f=this.closest('form'); var checked=f.querySelectorAll('input[name=answer]:checked'); if(checked.length===0){event.preventDefault(); return;} var vals=[]; checked.forEach(function(c){vals.push(c.value);}); var h=document.createElement('input'); h.type='hidden'; h.name='answer'; h.value=vals.join(', '); f.appendChild(h); checked.forEach(function(c){c.disabled=true;});">Submit</button>
+            {% else %}
             {% for choice in choices %}
             <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
             {% endfor %}
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
+            {% endif %}
+            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn, .chat-option-checkbox').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
                     <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore required></textarea>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -1,176 +1,51 @@
-{# ABOUTME: Chat transcript partial with avatar initials and message continuations. #}
-{# ABOUTME: SSE-refreshed via parent compositor; shows grouped messages and question cards. #}
+{# ABOUTME: Chat transcript wrapper combining message feed and question card as separate HTMX targets. #}
+{# ABOUTME: Feed refreshes on transcript_appended; question card refreshes on question_asked/answered. #}
 
-<div id="{{ container_id }}"
-     class="chat-transcript-wrap"
-     hx-trigger="sse:transcript_appended, sse:question_asked, sse:question_answered"
-     hx-get="/web/specs/{{ spec_id }}/activity/transcript?container_id={{ container_id }}"
-     hx-target="#{{ container_id }}"
-     hx-swap="outerHTML">
-    <div class="chat-messages" id="{{ container_id }}-feed">
-        {% for entry in transcript %}
-        {% if entry.is_step %}
-        <div class="chat-status-line">
-            <span class="status-dot dot-{{ entry.role_class }}"></span>
-            <span class="chat-status-body">{{ entry.sender_label }} {{ entry.content }}</span>
-            <span class="chat-status-time">{{ entry.timestamp }}</span>
-            {% if entry.repeat_count > 1 %}
-            <span class="chat-status-repeat">(&times;{{ entry.repeat_count }})</span>
-            {% endif %}
-        </div>
-        {% else %}
-        <div class="chat-message {% if entry.is_continuation %}chat-continuation{% endif %}">
-            {% if !entry.is_continuation %}
-            <div class="chat-message-header">
-                <div class="chat-avatar avatar-{{ entry.role_class }}">{{ entry.initial }}</div>
-                <span class="chat-sender">{{ entry.sender_label }}</span>
-                <span class="chat-time">{{ entry.timestamp }}</span>
-            </div>
-            {% endif %}
-            <div class="chat-body">{{ entry.content_html|safe }}</div>
-        </div>
-        {% endif %}
-        {% endfor %}
-        <div id="{{ container_id }}-throbber" class="chat-throbber" style="display:none;">
-            <div class="chat-message">
-                <div class="chat-message-header">
-                    <div class="chat-avatar avatar-manager">O</div>
-                    <span class="chat-sender">Orchestrator</span>
-                </div>
-                <div class="chat-body">
-                    <span class="thinking-dots"><span></span><span></span><span></span></span>
-                </div>
-            </div>
-        </div>
-        <div id="{{ container_id }}-streaming" class="chat-streaming-msg" style="display:none;">
-            <div class="chat-message">
-                <div class="chat-message-header">
-                    <div class="chat-avatar avatar-manager">O</div>
-                    <span class="chat-sender">Orchestrator</span>
-                </div>
-                <div class="chat-body" id="{{ container_id }}-streaming-body"></div>
-            </div>
-        </div>
-        <div id="{{ container_id }}-activity" class="chat-activity-status" style="display:none;">
-            <span class="status-dot dot-agent"></span>
-            <span id="{{ container_id }}-activity-text"></span>
-        </div>
-        {% if transcript.is_empty() %}
-        <div class="chat-empty">
-            <div class="chat-empty-icon">&#128172;</div>
-            <p class="chat-empty-title">No messages yet</p>
-            <p class="chat-empty-hint">Type below to start a conversation with the agents.</p>
-        </div>
-        {% endif %}
-    </div>
-
-    {% match pending_question %}
-    {% when Some with (q) %}
-    <div class="chat-question-card">
-        <div class="chat-message-header">
-            <div class="chat-avatar avatar-question">?</div>
-            <span class="chat-sender">Quick decision</span>
-        </div>
-        {% match q %}
-        {% when QuestionData::Boolean { question_id, question, default } %}
-        <div class="chat-question-body">{{ question|safe }}</div>
-        <form hx-post="/web/specs/{{ spec_id }}/answer"
-              hx-target="#{{ container_id }}"
-              hx-swap="outerHTML"
-              autocomplete="off"
-              class="chat-question-options">
-            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
-            <button type="submit" name="answer" value="Yes" class="chat-option-btn">Yes</button>
-            <button type="submit" name="answer" value="No" class="chat-option-btn">No</button>
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
-            <div class="chat-else-expand" style="display:none;">
-                <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore></textarea>
-                    <button type="submit" class="btn btn-send" title="Send">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
-                    </button>
-                </div>
-            </div>
-        </form>
-
-        {% when QuestionData::MultipleChoice { question_id, question, choices, allow_multi } %}
-        <div class="chat-question-body">{{ question|safe }}</div>
-        <form hx-post="/web/specs/{{ spec_id }}/answer"
-              hx-target="#{{ container_id }}"
-              hx-swap="outerHTML"
-              autocomplete="off"
-              class="chat-question-options">
-            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
-            {% if allow_multi %}
-            {% for choice in choices %}
-            <label class="chat-option-checkbox">
-                <input type="checkbox" name="answer" value="{{ choice }}">
-                <span>{{ choice }}</span>
-            </label>
-            {% endfor %}
-            <button type="submit" class="chat-option-btn chat-option-submit" onclick="var f=this.closest('form'); var checked=f.querySelectorAll('input[name=answer]:checked'); if(checked.length===0){event.preventDefault(); return;} var vals=[]; checked.forEach(function(c){vals.push(c.value);}); var h=document.createElement('input'); h.type='hidden'; h.name='answer'; h.value=vals.join(', '); f.appendChild(h); checked.forEach(function(c){c.disabled=true;});">Submit</button>
-            {% else %}
-            {% for choice in choices %}
-            <button type="submit" name="answer" value="{{ choice }}" class="chat-option-btn">{{ choice }}</button>
-            {% endfor %}
-            {% endif %}
-            <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn, .chat-option-checkbox').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
-            <div class="chat-else-expand" style="display:none;">
-                <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore></textarea>
-                    <button type="submit" class="btn btn-send" title="Send">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
-                    </button>
-                </div>
-            </div>
-        </form>
-
-        {% when QuestionData::Freeform { question_id, question, placeholder } %}
-        <div class="chat-question-body">{{ question|safe }}</div>
-        <form hx-post="/web/specs/{{ spec_id }}/answer"
-              hx-target="#{{ container_id }}"
-              hx-swap="outerHTML"
-              autocomplete="off"
-              class="chat-question-options">
-            <input type="hidden" name="question_id" value="{{ question_id }}" data-1p-ignore>
-            <div class="chat-input-row">
-                <textarea name="answer" placeholder="{{ placeholder }}" rows="1" data-1p-ignore required></textarea>
-                <button type="submit" class="btn btn-send" title="Send">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
-                </button>
-            </div>
-        </form>
-        {% endmatch %}
-    </div>
-    {% when None %}
-    {% endmatch %}
+<div id="{{ container_id }}" class="chat-transcript-wrap">
+    {% include "partials/chat_feed.html" %}
+    {% include "partials/chat_question.html" %}
 </div>
 
 <script>
+    // Toggle between the structured options and the free-text "something else" input.
+    // Called from onclick handlers in question card buttons.
+    function toggleElse(btn, showElse) {
+        var form = btn.closest('.chat-question-options');
+        var optSet = form.querySelector('.chat-options-set');
+        var expand = form.querySelector('.chat-else-expand');
+        var ta = expand.querySelector('textarea');
+        if (showElse) {
+            optSet.style.display = 'none';
+            expand.style.display = 'flex';
+            ta.name = 'answer';
+            ta.focus();
+        } else {
+            optSet.style.display = '';
+            expand.style.display = 'none';
+            ta.value = '';
+            ta.removeAttribute('name');
+        }
+    }
+
     (function() {
         var feedId = '{{ container_id }}-feed';
         var feed = document.getElementById(feedId);
         if (feed) feed.scrollTop = feed.scrollHeight;
 
-        // Save scroll position before swap, restore after
+        // Scroll preservation for feed-only swaps
         document.body.addEventListener('htmx:beforeSwap', function(evt) {
-            if (evt.detail.target && evt.detail.target.id === '{{ container_id }}') {
-                var f = document.getElementById(feedId);
-                if (f) {
-                    // Store whether user was scrolled to bottom
-                    var atBottom = (f.scrollHeight - f.scrollTop - f.clientHeight) < 50;
-                    evt.detail.target._wasAtBottom = atBottom;
-                    evt.detail.target._scrollTop = f.scrollTop;
-                }
+            if (evt.detail.target && evt.detail.target.id === feedId) {
+                var f = evt.detail.target;
+                var atBottom = (f.scrollHeight - f.scrollTop - f.clientHeight) < 50;
+                f._wasAtBottom = atBottom;
+                f._scrollTop = f.scrollTop;
             }
         });
 
         document.body.addEventListener('htmx:afterSwap', function(evt) {
-            if (evt.detail.target && evt.detail.target.id === '{{ container_id }}') {
+            if (evt.detail.target && evt.detail.target.id === feedId) {
                 var f = document.getElementById(feedId);
                 if (!f) return;
-                // If user was at bottom (or close), scroll to new bottom
-                // Otherwise restore their scroll position
                 var prev = evt.detail.target;
                 if (prev._wasAtBottom !== false) {
                     f.scrollTop = f.scrollHeight;
@@ -241,7 +116,7 @@
                 if (f) f.scrollTop = f.scrollHeight;
             });
 
-            // Hide streaming div when transcript_appended arrives (HTMX will re-render)
+            // Hide streaming div when transcript_appended arrives (HTMX will re-render feed)
             compositor.addEventListener('sse:transcript_appended', function() {
                 var sm = document.getElementById(streamingId);
                 if (sm) sm.style.display = 'none';

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -3,7 +3,7 @@
 
 <div id="{{ container_id }}"
      class="chat-transcript-wrap"
-     hx-trigger="sse:transcript_appended, sse:question_asked, sse:question_answered, sse:agent_step_started, sse:agent_step_finished"
+     hx-trigger="sse:transcript_appended, sse:question_asked, sse:question_answered"
      hx-get="/web/specs/{{ spec_id }}/activity/transcript?container_id={{ container_id }}"
      hx-target="#{{ container_id }}"
      hx-swap="outerHTML">
@@ -28,6 +28,17 @@
         </div>
         {% endif %}
         {% endfor %}
+        <div id="{{ container_id }}-throbber" class="chat-throbber" style="display:none;">
+            <div class="chat-message">
+                <div class="chat-message-header">
+                    <div class="chat-avatar avatar-manager">O</div>
+                    <span class="chat-sender">Orchestrator</span>
+                </div>
+                <div class="chat-body">
+                    <span class="thinking-dots"><span></span><span></span><span></span></span>
+                </div>
+            </div>
+        </div>
         {% if transcript.is_empty() %}
         <div class="chat-empty">
             <div class="chat-empty-icon">&#128172;</div>
@@ -142,5 +153,20 @@
                 }
             }
         });
+
+        var compositor = document.querySelector('.spec-compositor');
+        var throbberId = '{{ container_id }}-throbber';
+        if (compositor) {
+            compositor.addEventListener('sse:agent_step_started', function() {
+                var th = document.getElementById(throbberId);
+                if (th) { th.style.display = ''; }
+                var f = document.getElementById(feedId);
+                if (f) { f.scrollTop = f.scrollHeight; }
+            });
+            compositor.addEventListener('sse:agent_step_finished', function() {
+                var th = document.getElementById(throbberId);
+                if (th) { th.style.display = 'none'; }
+            });
+        }
     })();
 </script>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -85,7 +85,7 @@
             <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore required></textarea>
+                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore></textarea>
                     <button type="submit" class="btn btn-send" title="Send">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                     </button>
@@ -117,7 +117,7 @@
             <button type="button" class="chat-option-btn chat-option-else" onclick="var f=this.closest('.chat-question-options'); f.querySelectorAll('.chat-option-btn, .chat-option-checkbox').forEach(function(b){b.style.display='none'}); f.querySelector('.chat-else-expand').style.display='flex'; f.querySelector('.chat-else-expand textarea').name='answer'; f.querySelector('.chat-else-expand textarea').focus();">Something else&hellip;</button>
             <div class="chat-else-expand" style="display:none;">
                 <div class="chat-input-row">
-                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore required></textarea>
+                    <textarea placeholder="Describe what you mean..." rows="1" data-1p-ignore></textarea>
                     <button type="submit" class="btn btn-send" title="Send">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                     </button>

--- a/templates/partials/chat_transcript.html
+++ b/templates/partials/chat_transcript.html
@@ -42,6 +42,19 @@
                 </div>
             </div>
         </div>
+        <div id="{{ container_id }}-streaming" class="chat-streaming-msg" style="display:none;">
+            <div class="chat-message">
+                <div class="chat-message-header">
+                    <div class="chat-avatar avatar-manager">O</div>
+                    <span class="chat-sender">Orchestrator</span>
+                </div>
+                <div class="chat-body" id="{{ container_id }}-streaming-body"></div>
+            </div>
+        </div>
+        <div id="{{ container_id }}-activity" class="chat-activity-status" style="display:none;">
+            <span class="status-dot dot-agent"></span>
+            <span id="{{ container_id }}-activity-text"></span>
+        </div>
         {% if transcript.is_empty() %}
         <div class="chat-empty">
             <div class="chat-empty-icon">&#128172;</div>
@@ -179,6 +192,67 @@
             compositor.addEventListener('sse:agent_step_finished', function() {
                 var th = document.getElementById(throbberId);
                 if (th) { th.style.display = 'none'; }
+            });
+
+            var streamingId = '{{ container_id }}-streaming';
+            var streamingBodyId = '{{ container_id }}-streaming-body';
+            var activityId = '{{ container_id }}-activity';
+            var activityTextId = '{{ container_id }}-activity-text';
+
+            compositor.addEventListener('sse:streaming_delta', function(evt) {
+                var data = {};
+                try { data = JSON.parse(evt.detail.data || '{}'); } catch(e) {}
+                if (!data.payload || data.payload.type !== 'StreamingDelta') return;
+                var text = data.payload.text || '';
+
+                // Hide throbber, show streaming message
+                var th = document.getElementById(throbberId);
+                if (th) th.style.display = 'none';
+                var act = document.getElementById(activityId);
+                if (act) act.style.display = 'none';
+
+                var sm = document.getElementById(streamingId);
+                var sb = document.getElementById(streamingBodyId);
+                if (sm && sb) {
+                    sm.style.display = '';
+                    sb.textContent += text;
+                }
+
+                // Auto-scroll
+                var f = document.getElementById(feedId);
+                if (f) f.scrollTop = f.scrollHeight;
+            });
+
+            compositor.addEventListener('sse:streaming_tool_activity', function(evt) {
+                var data = {};
+                try { data = JSON.parse(evt.detail.data || '{}'); } catch(e) {}
+                if (!data.payload || data.payload.type !== 'StreamingToolActivity') return;
+                var activity = data.payload.activity || '';
+
+                var act = document.getElementById(activityId);
+                var actText = document.getElementById(activityTextId);
+                if (act && actText) {
+                    act.style.display = '';
+                    actText.textContent = activity;
+                }
+
+                // Auto-scroll
+                var f = document.getElementById(feedId);
+                if (f) f.scrollTop = f.scrollHeight;
+            });
+
+            // Hide streaming div when transcript_appended arrives (HTMX will re-render)
+            compositor.addEventListener('sse:transcript_appended', function() {
+                var sm = document.getElementById(streamingId);
+                if (sm) sm.style.display = 'none';
+                var sb = document.getElementById(streamingBodyId);
+                if (sb) sb.textContent = '';
+            });
+
+            // Hide activity on agent_step_finished
+            compositor.addEventListener('sse:agent_step_finished', function() {
+                var act = document.getElementById(activityId);
+                if (act) act.style.display = 'none';
             });
         }
     })();

--- a/templates/partials/create_spec_form.html
+++ b/templates/partials/create_spec_form.html
@@ -1,7 +1,7 @@
 {# ABOUTME: Form for creating a new spec from a free-text description. #}
 {# ABOUTME: The manager agent will parse the description into structured fields. #}
 
-<div class="create-spec-form" style="padding: var(--spacing-lg); max-width: 500px; margin: 0 auto;">
+<div class="create-spec-form">
     <h2>What do you want to build?</h2>
     <p style="color: var(--text-secondary); margin-bottom: var(--spacing-md); font-size: 0.85rem;">
         Describe your idea in your own words. Our agents will break it down into a structured spec.

--- a/templates/partials/create_spec_form.html
+++ b/templates/partials/create_spec_form.html
@@ -3,7 +3,7 @@
 
 <div class="create-spec-form">
     <h2>What do you want to build?</h2>
-    <p style="color: var(--text-secondary); margin-bottom: var(--spacing-md); font-size: 0.85rem;">
+    <p class="form-hint">
         Describe your idea in your own words. Our agents will break it down into a structured spec.
     </p>
     <form hx-post="/web/specs" hx-target="#workspace" hx-swap="innerHTML" hx-push-url="true">

--- a/templates/partials/document.html
+++ b/templates/partials/document.html
@@ -17,7 +17,7 @@
                 title="Save exports to disk">
             Export to Disk
         </button>
-        <a href="/web/specs/{{ spec_id }}/export/markdown" download class="btn btn-sm">Download .md</a>
+        <a href="/web/specs/{{ spec_id }}/export/markdown" download="{{ title_slug }}-spec.md" class="btn btn-sm">Download .md</a>
         <span class="regen-status"></span>
     </div>
     <h1>{{ title }}</h1>

--- a/templates/partials/document.html
+++ b/templates/partials/document.html
@@ -11,6 +11,7 @@
         <button class="btn btn-sm btn-export"
                 hx-post="/web/specs/{{ spec_id }}/regenerate"
                 hx-target=".regen-status" hx-swap="innerHTML"
+                hx-indicator=".btn-export"
                 title="Save exports to disk">
             Export to Disk
         </button>

--- a/templates/partials/document.html
+++ b/templates/partials/document.html
@@ -1,3 +1,5 @@
+{# ABOUTME: Rendered narrative document view of a spec, loaded into the canvas area. #}
+{# ABOUTME: Shows goal, description, constraints, success criteria, risks, notes, and lane cards. #}
 <div class="document">
     <div class="document-notice">
         <span class="notice-icon">&#9432;</span>

--- a/templates/partials/document.html
+++ b/templates/partials/document.html
@@ -15,6 +15,7 @@
                 title="Save exports to disk">
             Export to Disk
         </button>
+        <a href="/web/specs/{{ spec_id }}/export/markdown" download class="btn btn-sm">Download .md</a>
         <span class="regen-status"></span>
     </div>
     <h1>{{ title }}</h1>

--- a/templates/partials/import_spec_form.html
+++ b/templates/partials/import_spec_form.html
@@ -3,7 +3,7 @@
 
 <div class="create-spec-form">
     <h2>Import a spec</h2>
-    <p style="color: var(--text-secondary); margin-bottom: var(--spacing-md); font-size: 0.85rem;">
+    <p class="form-hint">
         Paste any content &mdash; DOT files, YAML, PRDs, napkin notes &mdash; and our LLM will extract the structure.
     </p>
     <form hx-post="/web/specs/import" hx-target="#workspace" hx-swap="innerHTML" hx-push-url="true">
@@ -11,9 +11,9 @@
             <textarea id="content" name="content" required rows="10"
                 placeholder="Paste your spec content here...&#10;&#10;Examples:&#10;- A DOT graph&#10;- A YAML spec&#10;- A product requirements doc&#10;- A list of ideas on a napkin"></textarea>
         </div>
-        <div class="form-group" style="margin-bottom: var(--spacing-md);">
-            <label for="source_format" style="font-size: 0.8rem; color: var(--text-secondary);">Format hint (optional)</label>
-            <select id="source_format" name="source_format" style="margin-top: 4px; width: 100%;">
+        <div class="form-group">
+            <label for="source_format" class="form-label">Format hint (optional)</label>
+            <select id="source_format" name="source_format" class="form-select">
                 <option value="auto">Auto-detect</option>
                 <option value="dot">DOT graph</option>
                 <option value="yaml">YAML</option>

--- a/templates/partials/import_spec_form.html
+++ b/templates/partials/import_spec_form.html
@@ -1,7 +1,7 @@
 {# ABOUTME: Form for importing a spec from arbitrary text via LLM extraction. #}
 {# ABOUTME: Accepts pasted content (DOT, YAML, PRDs, notes) and an optional format hint. #}
 
-<div class="create-spec-form" style="padding: var(--spacing-lg); max-width: 500px; margin: 0 auto;">
+<div class="create-spec-form">
     <h2>Import a spec</h2>
     <p style="color: var(--text-secondary); margin-bottom: var(--spacing-md); font-size: 0.85rem;">
         Paste any content &mdash; DOT files, YAML, PRDs, napkin notes &mdash; and our LLM will extract the structure.

--- a/templates/partials/import_spec_form.html
+++ b/templates/partials/import_spec_form.html
@@ -11,7 +11,7 @@
             <textarea id="content" name="content" required rows="10"
                 placeholder="Paste your spec content here...&#10;&#10;Examples:&#10;- A DOT graph&#10;- A YAML spec&#10;- A product requirements doc&#10;- A list of ideas on a napkin"></textarea>
         </div>
-        <div class="form-group format-hint-group">
+        <div class="form-group">
             <label for="source_format" class="form-label">Format hint (optional)</label>
             <select id="source_format" name="source_format" class="form-select">
                 <option value="auto">Auto-detect</option>

--- a/templates/partials/import_spec_form.html
+++ b/templates/partials/import_spec_form.html
@@ -11,7 +11,7 @@
             <textarea id="content" name="content" required rows="10"
                 placeholder="Paste your spec content here...&#10;&#10;Examples:&#10;- A DOT graph&#10;- A YAML spec&#10;- A product requirements doc&#10;- A list of ideas on a napkin"></textarea>
         </div>
-        <div class="form-group">
+        <div class="form-group format-hint-group">
             <label for="source_format" class="form-label">Format hint (optional)</label>
             <select id="source_format" name="source_format" class="form-select">
                 <option value="auto">Auto-detect</option>

--- a/templates/partials/phase_stepper.html
+++ b/templates/partials/phase_stepper.html
@@ -1,0 +1,34 @@
+{# ABOUTME: Linear phase stepper showing Brainstorm → Refine → Complete progression. #}
+{# ABOUTME: Clickable steps trigger phase transitions via HTMX POST. #}
+
+{% let phases = [("brainstorming", "Brainstorm", "1"), ("refining", "Refine", "2"), ("complete", "Complete", "3")] %}
+
+<nav class="phase-stepper" aria-label="Spec phases">
+    {% for (phase_id, label, number) in phases %}
+    {% if !loop.first %}
+    <div class="phase-step-connector{% if self.is_completed(phase_id) %} connector-completed{% endif %}"></div>
+    {% endif %}
+
+    {% if *phase_id == phase %}
+    <div class="phase-step step-active" aria-current="step">
+        <span class="phase-step-number">{{ number }}</span>
+        <span class="phase-step-label">{{ label }}</span>
+    </div>
+    {% else if self.is_completed(phase_id) %}
+    <button class="phase-step step-completed"
+            hx-post="/web/specs/{{ spec_id }}/phase"
+            hx-vals='{"target":"{{ phase_id }}"}'
+            hx-swap="none"
+            title="Return to {{ label }}">
+        <span class="phase-step-number">✓</span>
+        <span class="phase-step-label">{{ label }}</span>
+    </button>
+    {% else %}
+    <div class="phase-step step-disabled"
+         title="{{ self.disabled_tooltip(phase_id) }}">
+        <span class="phase-step-number">{{ number }}</span>
+        <span class="phase-step-label">{{ label }}</span>
+    </div>
+    {% endif %}
+    {% endfor %}
+</nav>

--- a/templates/partials/phase_stepper.html
+++ b/templates/partials/phase_stepper.html
@@ -21,13 +21,13 @@
             hx-swap="none">
         <span class="phase-step-number">✓</span>
         <span class="phase-step-label">{{ label }}</span>
-        <span class="phase-step-tooltip">Return to {{ label }}</span>
+        <span class="tooltip phase-step-tooltip">Return to {{ label }}</span>
     </button>
     {% else %}
     <div class="phase-step step-disabled">
         <span class="phase-step-number">{{ number }}</span>
         <span class="phase-step-label">{{ label }}</span>
-        <span class="phase-step-tooltip">{{ self.disabled_tooltip(phase_id) }}</span>
+        <span class="tooltip phase-step-tooltip">{{ self.disabled_tooltip(phase_id) }}</span>
     </div>
     {% endif %}
     {% endfor %}

--- a/templates/partials/phase_stepper.html
+++ b/templates/partials/phase_stepper.html
@@ -18,16 +18,16 @@
     <button class="phase-step step-completed"
             hx-post="/web/specs/{{ spec_id }}/phase"
             hx-vals='{"target":"{{ phase_id }}"}'
-            hx-swap="none"
-            title="Return to {{ label }}">
+            hx-swap="none">
         <span class="phase-step-number">✓</span>
         <span class="phase-step-label">{{ label }}</span>
+        <span class="phase-step-tooltip">Return to {{ label }}</span>
     </button>
     {% else %}
-    <div class="phase-step step-disabled"
-         title="{{ self.disabled_tooltip(phase_id) }}">
+    <div class="phase-step step-disabled">
         <span class="phase-step-number">{{ number }}</span>
         <span class="phase-step-label">{{ label }}</span>
+        <span class="phase-step-tooltip">{{ self.disabled_tooltip(phase_id) }}</span>
     </div>
     {% endif %}
     {% endfor %}

--- a/templates/partials/spec.html
+++ b/templates/partials/spec.html
@@ -1,14 +1,35 @@
-{# ABOUTME: Workflow tab placeholder for DAG visualization of the pipeline. #}
-{# ABOUTME: Will render dippin-lang workflow graph; currently shows structural summary. #}
+{# ABOUTME: Spec tab that renders a synthesized specification document from cards grouped by type. #}
+{# ABOUTME: Replaces the diagram tab; displays markdown-rendered spec with copy/download toolbar. #}
 
-<div class="workflow-placeholder">
+<div class="document spec-document">
     <div class="document-notice">
-        <span>Workflow visualization — coming soon.</span>
-        <a href="/web/specs/{{ spec_id }}/export/dot" download="workflow.dot" class="btn btn-sm btn-download">Download DOT</a>
+        <span>Synthesized from Plan &amp; Spec cards, grouped by type.</span>
+        <button class="btn btn-sm btn-regen"
+                hx-get="/web/specs/{{ spec_id }}/spec"
+                hx-target="#canvas" hx-swap="innerHTML"
+                title="Regenerate spec from current data">
+            Regenerate
+        </button>
+        <button class="btn btn-sm btn-copy" id="spec-copy-md" title="Copy Markdown source">Copy Markdown</button>
+        <a href="/web/specs/{{ spec_id }}/export/spec" download="spec.md" class="btn btn-sm btn-download">Download</a>
     </div>
 
-    <div class="workflow-summary">
-        <h2>Pipeline Structure</h2>
-        <p class="muted">A visual DAG editor will replace this view. For now, the pipeline structure is available as a DOT export.</p>
+    <div class="doc-content">
+        {{ spec_html|safe }}
     </div>
 </div>
+
+<script>
+    (function() {
+        var md = {{ spec_markdown|json|safe }};
+        var copyBtn = document.getElementById('spec-copy-md');
+        if (copyBtn && md) {
+            copyBtn.addEventListener('click', function() {
+                navigator.clipboard.writeText(md).then(function() {
+                    copyBtn.textContent = 'Copied!';
+                    setTimeout(function() { copyBtn.textContent = 'Copy Markdown'; }, 2000);
+                });
+            });
+        }
+    })();
+</script>

--- a/templates/partials/spec.html
+++ b/templates/partials/spec.html
@@ -1,35 +1,14 @@
-{# ABOUTME: Spec tab that renders a synthesized specification document from cards grouped by type. #}
-{# ABOUTME: Replaces the diagram tab; displays markdown-rendered spec with copy/download toolbar. #}
+{# ABOUTME: Workflow tab placeholder for DAG visualization of the pipeline. #}
+{# ABOUTME: Will render dippin-lang workflow graph; currently shows structural summary. #}
 
-<div class="document spec-document">
+<div class="workflow-placeholder">
     <div class="document-notice">
-        <span>Synthesized from Plan &amp; Spec cards, grouped by type.</span>
-        <button class="btn btn-sm btn-regen"
-                hx-get="/web/specs/{{ spec_id }}/spec"
-                hx-target="#canvas" hx-swap="innerHTML"
-                title="Regenerate spec from current data">
-            Regenerate
-        </button>
-        <button class="btn btn-sm btn-copy" id="spec-copy-md" title="Copy Markdown source">Copy Markdown</button>
-        <a href="/web/specs/{{ spec_id }}/export/spec" download="spec.md" class="btn btn-sm btn-download">Download</a>
+        <span>Workflow visualization — coming soon.</span>
+        <a href="/web/specs/{{ spec_id }}/export/dot" download="workflow.dot" class="btn btn-sm btn-download">Download DOT</a>
     </div>
 
-    <div class="doc-content">
-        {{ spec_html|safe }}
+    <div class="workflow-summary">
+        <h2>Pipeline Structure</h2>
+        <p class="muted">A visual DAG editor will replace this view. For now, the pipeline structure is available as a DOT export.</p>
     </div>
 </div>
-
-<script>
-    (function() {
-        var md = {{ spec_markdown|json|safe }};
-        var copyBtn = document.getElementById('spec-copy-md');
-        if (copyBtn && md) {
-            copyBtn.addEventListener('click', function() {
-                navigator.clipboard.writeText(md).then(function() {
-                    copyBtn.textContent = 'Copied!';
-                    setTimeout(function() { copyBtn.textContent = 'Copy Markdown'; }, 2000);
-                });
-            });
-        }
-    })();
-</script>

--- a/templates/partials/spec.html
+++ b/templates/partials/spec.html
@@ -11,7 +11,7 @@
             Regenerate
         </button>
         <button class="btn btn-sm btn-copy" id="spec-copy-md" title="Copy Markdown source">Copy Markdown</button>
-        <a href="/web/specs/{{ spec_id }}/export/spec" download="spec.md" class="btn btn-sm btn-download">Download</a>
+        <a href="/web/specs/{{ spec_id }}/export/spec" download="{{ title_slug }}-spec.md" class="btn btn-sm btn-download">Download</a>
     </div>
 
     <div class="doc-content">

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -27,13 +27,6 @@
 </header>
 
 <div class="spec-body">
-    <div id="agents-offline-banner" class="agents-offline-banner" style="display:none;">
-        <span>Agents are not running.</span>
-        <button class="btn btn-sm btn-start-agents"
-                hx-post="/web/specs/{{ spec_id }}/agents/start"
-                hx-target="#agent-controls"
-                hx-swap="innerHTML">Start Agents</button>
-    </div>
     <main class="canvas" id="canvas"
           hx-get="/web/specs/{{ spec_id }}/chat-panel"
           hx-trigger="load" hx-swap="innerHTML">
@@ -48,6 +41,14 @@
     {% else %}
     <div id="agent-canvas" style="display:none;"></div>
     {% endif %}
+</div>
+<div id="agents-offline-banner" class="agents-offline-banner">
+    <button class="agents-offline-dismiss" onclick="this.parentElement.style.display='none'" title="Dismiss">&times;</button>
+    <span>Agents are not running.</span>
+    <button class="btn btn-start-agents"
+            hx-post="/web/specs/{{ spec_id }}/agents/start"
+            hx-target="#agent-controls"
+            hx-swap="innerHTML">Start Agents</button>
 </div>
 
 </div>
@@ -162,13 +163,6 @@
 </header>
 
 <div class="spec-body">
-    <div id="agents-offline-banner" class="agents-offline-banner" style="display:none;">
-        <span>Agents are not running.</span>
-        <button class="btn btn-sm btn-start-agents"
-                hx-post="/web/specs/{{ spec_id }}/agents/start"
-                hx-target="#agent-controls"
-                hx-swap="innerHTML">Start Agents</button>
-    </div>
     <main class="canvas" id="canvas"
           hx-get="/web/specs/{{ spec_id }}/document"
           hx-trigger="load" hx-swap="innerHTML">
@@ -177,6 +171,14 @@
            hx-get="/web/specs/{{ spec_id }}/chat-panel"
            hx-trigger="load" hx-swap="innerHTML">
     </aside>
+</div>
+<div id="agents-offline-banner" class="agents-offline-banner">
+    <button class="agents-offline-dismiss" onclick="this.parentElement.style.display='none'" title="Dismiss">&times;</button>
+    <span>Agents are not running.</span>
+    <button class="btn btn-start-agents"
+            hx-post="/web/specs/{{ spec_id }}/agents/start"
+            hx-target="#agent-controls"
+            hx-swap="innerHTML">Start Agents</button>
 </div>
 
 </div>

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -8,9 +8,7 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title">{{ title }}
-            <span class="command-bar-tooltip">{{ one_liner }}</span>
-        </span>
+        <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
     </div>
@@ -19,6 +17,7 @@
              hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
              hx-swap="innerHTML"></div>
     </div>
+    <span class="tooltip command-bar-tooltip">{{ one_liner }}</span>
 </header>
 {% include "partials/phase_stepper.html" %}
 
@@ -101,9 +100,7 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title">{{ title }}
-            <span class="command-bar-tooltip">{{ one_liner }}</span>
-        </span>
+        <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
     </div>
@@ -112,6 +109,7 @@
              hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
              hx-swap="innerHTML"></div>
     </div>
+    <span class="tooltip command-bar-tooltip">{{ one_liner }}</span>
 </header>
 {% include "partials/phase_stepper.html" %}
 <div class="view-toggles-row">
@@ -242,14 +240,13 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title">{{ title }}
-            <span class="command-bar-tooltip">{{ one_liner }}</span>
-        </span>
+        <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
     </div>
     <div class="command-bar-right">
     </div>
+    <span class="tooltip command-bar-tooltip">{{ one_liner }}</span>
 </header>
 {% include "partials/phase_stepper.html" %}
 

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -60,12 +60,14 @@
             btnBoard.addEventListener('click', function() {
                 btnBoard.style.display = 'none';
                 btnChat.style.display = '';
+                document.getElementById('canvas').classList.add('canvas-board');
             });
         }
         if (btnChat) {
             btnChat.addEventListener('click', function() {
                 btnChat.style.display = 'none';
                 btnBoard.style.display = '';
+                document.getElementById('canvas').classList.remove('canvas-board');
             });
         }
 

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -8,10 +8,11 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
+        <span class="command-bar-title">{{ title }}
+            <span class="command-bar-tooltip">{{ one_liner }}</span>
+        </span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
-        <div class="command-bar-popover">{{ one_liner }}</div>
     </div>
     <div class="command-bar-right">
         <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
@@ -100,10 +101,11 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
+        <span class="command-bar-title">{{ title }}
+            <span class="command-bar-tooltip">{{ one_liner }}</span>
+        </span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
-        <div class="command-bar-popover">{{ one_liner }}</div>
     </div>
     <div class="command-bar-right">
         <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
@@ -240,10 +242,11 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
+        <span class="command-bar-title">{{ title }}
+            <span class="command-bar-tooltip">{{ one_liner }}</span>
+        </span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
-        <div class="command-bar-popover">{{ one_liner }}</div>
     </div>
     <div class="command-bar-right">
     </div>
@@ -284,13 +287,3 @@
 </script>
 
 {% endif %}
-
-<script>
-document.addEventListener('click', function(e) {
-    if (!e.target.closest('.command-bar-left')) {
-        document.querySelectorAll('.command-bar-left.popover-open').forEach(function(el) {
-            el.classList.remove('popover-open');
-        });
-    }
-});
-</script>

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -128,7 +128,7 @@
                 hx-get="/web/specs/{{ spec_id }}/spec"
                 hx-target="#canvas" hx-swap="innerHTML">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>
-            <span class="view-toggle-label">Workflow</span>
+            <span class="view-toggle-label">Spec</span>
         </button>
     </div>
 </div>

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -27,6 +27,13 @@
 </header>
 
 <div class="spec-body">
+    <div id="agents-offline-banner" class="agents-offline-banner" style="display:none;">
+        <span>Agents are not running.</span>
+        <button class="btn btn-sm btn-start-agents"
+                hx-post="/web/specs/{{ spec_id }}/agents/start"
+                hx-target="#agent-controls"
+                hx-swap="innerHTML">Start Agents</button>
+    </div>
     <main class="canvas" id="canvas"
           hx-get="/web/specs/{{ spec_id }}/chat-panel"
           hx-trigger="load" hx-swap="innerHTML">
@@ -93,8 +100,8 @@
     })();
 </script>
 
-{% else %}
-{# Active layout: tabs, chat rail, board/document/spec views #}
+{% else if phase == "refining" %}
+{# Refining layout: tabs, chat rail, board/document/workflow views #}
 <div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream">
 
 <header class="command-bar">
@@ -102,6 +109,7 @@
         <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
+        <span class="phase-badge phase-refining">Refining</span>
     </div>
     <div class="view-toggles-capsule">
         <button class="view-toggle active" data-view="document"
@@ -120,10 +128,14 @@
                 hx-get="/web/specs/{{ spec_id }}/spec"
                 hx-target="#canvas" hx-swap="innerHTML">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/></svg>
-            <span class="view-toggle-label">Spec</span>
+            <span class="view-toggle-label">Workflow</span>
         </button>
     </div>
     <div class="command-bar-right">
+        <button class="btn btn-sm"
+                hx-post="/web/specs/{{ spec_id }}/phase"
+                hx-vals='{"target":"complete"}'
+                hx-swap="none">Finalize Spec</button>
         <button class="btn btn-sm"
                 hx-post="/web/specs/{{ spec_id }}/phase"
                 hx-vals='{"target":"brainstorming"}'
@@ -135,6 +147,13 @@
 </header>
 
 <div class="spec-body">
+    <div id="agents-offline-banner" class="agents-offline-banner" style="display:none;">
+        <span>Agents are not running.</span>
+        <button class="btn btn-sm btn-start-agents"
+                hx-post="/web/specs/{{ spec_id }}/agents/start"
+                hx-target="#agent-controls"
+                hx-swap="innerHTML">Start Agents</button>
+    </div>
     <main class="canvas" id="canvas"
           hx-get="/web/specs/{{ spec_id }}/document"
           hx-trigger="load" hx-swap="innerHTML">
@@ -192,6 +211,46 @@
         compositor.addEventListener('sse:phase_transitioned', function() {
             htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
         });
+    })();
+</script>
+
+{% else %}
+{# Complete layout: read-only export with download buttons #}
+<div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream">
+
+<header class="command-bar">
+    <div class="command-bar-left">
+        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-chevron">&#8250;</span>
+        <span class="command-bar-subtitle">{{ one_liner }}</span>
+        <span class="phase-badge phase-complete">Complete</span>
+    </div>
+    <div class="command-bar-right">
+        <a href="/web/specs/{{ spec_id }}/export/markdown" download class="btn btn-sm">Download .md</a>
+        <button class="btn btn-sm"
+                hx-post="/web/specs/{{ spec_id }}/phase"
+                hx-vals='{"target":"refining"}'
+                hx-swap="none">Keep Refining</button>
+    </div>
+</header>
+
+<div class="spec-body">
+    <main class="canvas" id="canvas"
+          hx-get="/web/specs/{{ spec_id }}/document"
+          hx-trigger="load" hx-swap="innerHTML">
+    </main>
+</div>
+
+</div>
+
+<script>
+    (function() {
+        var compositor = document.querySelector('.spec-compositor');
+        if (compositor) {
+            compositor.addEventListener('sse:phase_transitioned', function() {
+                htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+            });
+        }
     })();
 </script>
 

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -8,9 +8,10 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
+        <div class="command-bar-popover">{{ one_liner }}</div>
     </div>
     <div class="command-bar-right">
         <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
@@ -99,9 +100,10 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
+        <div class="command-bar-popover">{{ one_liner }}</div>
     </div>
     <div class="command-bar-right">
         <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
@@ -221,9 +223,10 @@
 
 <header class="command-bar">
     <div class="command-bar-left">
-        <span class="command-bar-title">{{ title }}</span>
+        <span class="command-bar-title" onclick="this.parentElement.classList.toggle('popover-open')">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
+        <div class="command-bar-popover">{{ one_liner }}</div>
     </div>
     <div class="command-bar-right">
     </div>
@@ -264,3 +267,13 @@
 </script>
 
 {% endif %}
+
+<script>
+document.addEventListener('click', function(e) {
+    if (!e.target.closest('.command-bar-left')) {
+        document.querySelectorAll('.command-bar-left.popover-open').forEach(function(el) {
+            el.classList.remove('popover-open');
+        });
+    }
+});
+</script>

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -2,7 +2,7 @@
 {# ABOUTME: Loaded into #workspace when a spec is selected; layout varies by phase. #}
 
 {% if phase == "brainstorming" %}
-{# Brainstorming layout: full-width chat with agent canvas #}
+{# Brainstorming layout: command bar + stepper + full-width chat #}
 <div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream"
      data-view="brainstorming">
 
@@ -94,7 +94,7 @@
 </script>
 
 {% else if phase == "refining" %}
-{# Refining layout: tabs, chat rail, board/document/workflow views #}
+{# Refining layout: command bar + stepper + view toggles + canvas + chat rail #}
 <div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream">
 
 <header class="command-bar">

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -1,8 +1,8 @@
-{# ABOUTME: Spec compositor: command bar + canvas + chat rail. #}
-{# ABOUTME: Loaded into #workspace when a spec is selected; default view is the document canvas. #}
+{# ABOUTME: Spec compositor: command bar + phase stepper + canvas + chat rail. #}
+{# ABOUTME: Loaded into #workspace when a spec is selected; layout varies by phase. #}
 
 {% if phase == "brainstorming" %}
-{# Brainstorming layout: full-width chat, phase badge, view board button #}
+{# Brainstorming layout: full-width chat with agent canvas #}
 <div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream"
      data-view="brainstorming">
 
@@ -11,20 +11,14 @@
         <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
-        <span class="phase-badge phase-brainstorming">Brainstorming</span>
     </div>
     <div class="command-bar-right">
-        <button id="btn-view-board" class="btn btn-sm"
-                hx-get="/web/specs/{{ spec_id }}/board"
-                hx-target="#canvas" hx-swap="innerHTML">View Board</button>
-        <button id="btn-back-to-chat" class="btn btn-sm" style="display:none;"
-                hx-get="/web/specs/{{ spec_id }}/chat-panel"
-                hx-target="#canvas" hx-swap="innerHTML">Back to Chat</button>
         <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
              hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
              hx-swap="innerHTML"></div>
     </div>
 </header>
+{% include "partials/phase_stepper.html" %}
 
 <div class="spec-body">
     <main class="canvas" id="canvas"
@@ -55,23 +49,6 @@
 
 <script>
     (function() {
-        var btnBoard = document.getElementById('btn-view-board');
-        var btnChat = document.getElementById('btn-back-to-chat');
-        if (btnBoard) {
-            btnBoard.addEventListener('click', function() {
-                btnBoard.style.display = 'none';
-                btnChat.style.display = '';
-                document.getElementById('canvas').classList.add('canvas-board');
-            });
-        }
-        if (btnChat) {
-            btnChat.addEventListener('click', function() {
-                btnChat.style.display = 'none';
-                btnBoard.style.display = '';
-                document.getElementById('canvas').classList.remove('canvas-board');
-            });
-        }
-
         var compositor = document.querySelector('.spec-compositor');
         if (compositor) {
             compositor.addEventListener('sse:phase_transitioned', function() {
@@ -125,8 +102,15 @@
         <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
-        <span class="phase-badge phase-refining">Refining</span>
     </div>
+    <div class="command-bar-right">
+        <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
+             hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
+             hx-swap="innerHTML"></div>
+    </div>
+</header>
+{% include "partials/phase_stepper.html" %}
+<div class="view-toggles-row">
     <div class="view-toggles-capsule">
         <button class="view-toggle active" data-view="document"
                 hx-get="/web/specs/{{ spec_id }}/document"
@@ -147,20 +131,7 @@
             <span class="view-toggle-label">Workflow</span>
         </button>
     </div>
-    <div class="command-bar-right">
-        <button class="btn btn-sm"
-                hx-post="/web/specs/{{ spec_id }}/phase"
-                hx-vals='{"target":"complete"}'
-                hx-swap="none">Finalize Spec</button>
-        <button class="btn btn-sm"
-                hx-post="/web/specs/{{ spec_id }}/phase"
-                hx-vals='{"target":"brainstorming"}'
-                hx-swap="none">Resume Brainstorming</button>
-        <div id="agent-controls" hx-get="/web/specs/{{ spec_id }}/agents/status"
-             hx-trigger="load, sse:agent_step_started, sse:agent_step_finished, refreshAgents from:body"
-             hx-swap="innerHTML"></div>
-    </div>
-</header>
+</div>
 
 <div class="spec-body">
     <main class="canvas" id="canvas"
@@ -245,7 +216,7 @@
 </script>
 
 {% else %}
-{# Complete layout: read-only export with download buttons #}
+{# Complete layout: read-only export view #}
 <div class="spec-compositor" hx-ext="sse" sse-connect="/api/specs/{{ spec_id }}/events/stream">
 
 <header class="command-bar">
@@ -253,16 +224,11 @@
         <span class="command-bar-title">{{ title }}</span>
         <span class="command-bar-chevron">&#8250;</span>
         <span class="command-bar-subtitle">{{ one_liner }}</span>
-        <span class="phase-badge phase-complete">Complete</span>
     </div>
     <div class="command-bar-right">
-        <a href="/web/specs/{{ spec_id }}/export/markdown" download class="btn btn-sm">Download .md</a>
-        <button class="btn btn-sm"
-                hx-post="/web/specs/{{ spec_id }}/phase"
-                hx-vals='{"target":"refining"}'
-                hx-swap="none">Keep Refining</button>
     </div>
 </header>
+{% include "partials/phase_stepper.html" %}
 
 <div class="spec-body">
     <main class="canvas" id="canvas"

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -135,6 +135,11 @@
     </div>
 </div>
 
+<div class="mobile-content-tabs">
+    <button class="mobile-tab active" data-target="canvas" onclick="switchMobileTab(this, 'canvas')">Content</button>
+    <button class="mobile-tab" data-target="chat" onclick="switchMobileTab(this, 'chat')">Chat</button>
+</div>
+
 <div class="spec-body">
     <main class="canvas" id="canvas"
           hx-get="/web/specs/{{ spec_id }}/document"
@@ -166,6 +171,18 @@
             btn.classList.add('active');
         });
     });
+
+    // Mobile tab switcher: toggles between canvas and chat on small screens
+    function switchMobileTab(btn, target) {
+        document.querySelectorAll('.mobile-tab').forEach(function(t) { t.classList.remove('active'); });
+        btn.classList.add('active');
+        var body = document.querySelector('.spec-body');
+        if (target === 'chat') {
+            body.classList.add('show-chat');
+        } else {
+            body.classList.remove('show-chat');
+        }
+    }
 
     // Refresh agent status when agent controls are swapped (start/pause/resume)
     document.body.addEventListener('htmx:afterSwap', function(evt) {

--- a/templates/partials/spec_view.html
+++ b/templates/partials/spec_view.html
@@ -98,6 +98,19 @@
                     canvas.style.display = 'none';
                 }
             });
+
+            // Polling fallback: if SSE drops, check phase every 15 seconds
+            var currentPhase = '{{ phase }}';
+            setInterval(function() {
+                fetch('/web/specs/{{ spec_id }}/phase-check')
+                    .then(function(r) { return r.text(); })
+                    .then(function(serverPhase) {
+                        if (serverPhase !== currentPhase) {
+                            htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+                        }
+                    })
+                    .catch(function() {}); // silently ignore network errors
+            }, 15000);
         }
     })();
 </script>
@@ -213,6 +226,19 @@
         compositor.addEventListener('sse:phase_transitioned', function() {
             htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
         });
+
+        // Polling fallback: if SSE drops, check phase every 15 seconds
+        var currentPhase = '{{ phase }}';
+        setInterval(function() {
+            fetch('/web/specs/{{ spec_id }}/phase-check')
+                .then(function(r) { return r.text(); })
+                .then(function(serverPhase) {
+                    if (serverPhase !== currentPhase) {
+                        htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+                    }
+                })
+                .catch(function() {}); // silently ignore network errors
+        }, 15000);
     })();
 </script>
 
@@ -252,6 +278,19 @@
             compositor.addEventListener('sse:phase_transitioned', function() {
                 htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
             });
+
+            // Polling fallback: if SSE drops, check phase every 15 seconds
+            var currentPhase = '{{ phase }}';
+            setInterval(function() {
+                fetch('/web/specs/{{ spec_id }}/phase-check')
+                    .then(function(r) { return r.text(); })
+                    .then(function(serverPhase) {
+                        if (serverPhase !== currentPhase) {
+                            htmx.ajax('GET', '/web/specs/{{ spec_id }}', {target: '#workspace', swap: 'innerHTML'});
+                        }
+                    })
+                    .catch(function() {}); // silently ignore network errors
+            }, 15000);
         }
     })();
 </script>

--- a/templates/spec_page.html
+++ b/templates/spec_page.html
@@ -8,7 +8,7 @@
 <div class="rail-header">
     <span>Your specs</span>
 </div>
-<div class="spec-list" id="spec-list" hx-get="/web/specs" hx-trigger="load" hx-swap="innerHTML">
+<div class="spec-list" id="spec-list" hx-get="/web/specs" hx-trigger="load, every 30s" hx-swap="innerHTML">
     <p class="loading">Loading specs...</p>
 </div>
 <div id="provider-status" hx-get="/web/provider-status" hx-trigger="load" hx-swap="innerHTML">


### PR DESCRIPTION
## Summary

- **Phase wayfinding UI**: Layered command bar with title/subtitle, phase stepper showing progress through brainstorming → refining → complete, contextual view toggles (Document/Board/Spec) per phase
- **Mobile responsive**: Hamburger menu + drawer nav, content/chat tab switcher, collapsible phase stepper, tooltip popovers, overflow fixes
- **Streaming agent activity**: Live streaming deltas, thinking throbber, worker activity status line, streaming hook bridge
- **UX polish**: Slugified download filenames, auto-refresh sidebar, phase polling fallback, multi-select checkboxes, agents-offline overlay, chat improvements

## Test plan

- [x] `cargo test --all` passes (160 server tests, all green)
- [x] `cargo clippy --all-targets` clean
- [ ] Manual: verify phase stepper navigation on desktop
- [ ] Manual: verify hamburger menu + drawer on mobile viewport
- [ ] Manual: verify downloads produce correctly-named files
- [ ] Manual: verify streaming activity during agent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live token streaming display in chat during manager execution
  * Real-time worker activity status indicators
  * Phase stepper navigation for Brainstorm → Refine → Complete workflow
  * Mobile UI improvements including navigation drawer and responsive layout
  * Download filenames now reflect your spec title

* **UI/UX Improvements**
  * Redesigned phase transition navigation interface
  * Enhanced chat transcript with collapse controls and separate feed/question views
  * Agent status display improvements
  * Agents-offline notification banner

<!-- end of auto-generated comment: release notes by coderabbit.ai -->