### PR TITLE
fix(tauri): bundle static at Resources/static, fix launch crash

### DIFF
--- a/crates/barnstormer-tauri/src/lib.rs
+++ b/crates/barnstormer-tauri/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::Mutex;
 
 use barnstormer_runtime::{RuntimeOptions, ServerHandle, launch};
 use barnstormer_server::ProviderStatus;
+use tauri::path::BaseDirectory;
 use tauri::{Manager, Runtime};
 
 use settings::DesktopSettings;
@@ -168,7 +169,10 @@ fn open_settings_window<R: Runtime>(app: &tauri::AppHandle<R>) -> anyhow::Result
 }
 
 fn resolve_desktop_static_dir<R: Runtime>(app: &tauri::AppHandle<R>) -> anyhow::Result<PathBuf> {
-    let bundled_static_dir = app.path().resource_dir()?.join("static");
+    // Use Tauri's resource resolver instead of joining onto `resource_dir()` so
+    // the lookup matches whatever the bundler actually produced — including any
+    // path mangling the bundler applies for sources outside the Tauri crate.
+    let bundled_static_dir = app.path().resolve("static", BaseDirectory::Resource)?;
     if bundled_static_dir.exists() {
         return Ok(bundled_static_dir);
     }

--- a/crates/barnstormer-tauri/tauri.conf.json
+++ b/crates/barnstormer-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "active": true,
     "targets": ["app"],
     "icon": ["icons/icon.png", "icons/icon.icns"],
-    "resources": ["../../static"],
+    "resources": { "../../static": "static" },
     "macOS": {
       "minimumSystemVersion": "12.0"
     }


### PR DESCRIPTION
## Summary
- v0.2.0 DMG crashed on launch because the bundled `static/` assets landed at `Resources/_up_/_up_/static/` (Tauri encodes each `../` in the source path as `_up_`), but `resolve_desktop_static_dir` looked at `Resources/static/`. The missing-resource error returned through `setup()` panicked across the Tauri FFI boundary in `did_finish_launching` → SIGABRT.
- Switch `bundle.resources` to the destination-mapped object form so the bundler writes to `Resources/static/` directly.
- Use `BaseDirectory::Resource` for the lookup so future bundler path changes stay consistent with the resolver.

## Test plan
- [x] `cargo check -p barnstormer-tauri`
- [x] `cargo test -p barnstormer-tauri --lib` (8 passed)
- [ ] Tag `v0.2.1`, wait for `release-gui.yml` to build, download DMG, confirm app launches and reaches settings window

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/barnstormer/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved asset resolution configuration for the bundled application resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/barnstormer/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->