### PR TITLE
fix(tauri): set main window default size to 1440x900

### DIFF
--- a/crates/barnstormer-tauri/src/lib.rs
+++ b/crates/barnstormer-tauri/src/lib.rs
@@ -145,6 +145,10 @@ pub(crate) fn open_main_window<R: Runtime>(
 
     tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::External(local_url.parse()?))
         .title("Barnstormer")
+        .inner_size(1440.0, 900.0)
+        .min_inner_size(800.0, 600.0)
+        .resizable(true)
+        .center()
         .build()?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- The main webview window had no explicit size in `open_main_window`, so Tauri's tiny platform default opened a cramped window for Barnstormer's multi-panel layout.
- Set `inner_size(1440.0, 900.0)`, `min_inner_size(800.0, 600.0)`, `center()`, and explicit `resizable(true)`.

## Test plan
- [x] `cargo check -p barnstormer-tauri`
- [x] `cargo test -p barnstormer-tauri --lib`
- [ ] After tagging `v0.2.2` and downloading the new DMG, confirm the window opens at 1440x900 and respects the minimum size on resize

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/barnstormer/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Application window now initializes with optimized dimensions (1440x900) and a minimum size of 800x600
  * Window is now resizable and automatically centered on the screen

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/barnstormer/pull/16)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->