### PR TITLE
feat(cost): enable Anthropic prompt caching on agent system prompts and tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "mux"
 version = "0.10.0"
-source = "git+https://github.com/2389-research/mux-rs.git?tag=v0.13.0#6de1f7af7e049e71f1a51854177b60d15dbeb1ed"
+source = "git+https://github.com/2389-research/mux-rs.git?rev=1576618856f4b51d994b6ae70af376a0fbfb6b7f#1576618856f4b51d994b6ae70af376a0fbfb6b7f"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,10 @@ http = "1"
 pulldown-cmark = "0.12"
 reqwest = { version = "0.12", features = ["json"] }
 anyhow = "1"
-mux = { git = "https://github.com/2389-research/mux-rs.git", tag = "v0.13.0" }
+# Pinned to the mux-rs main commit that contains the Anthropic prompt-caching
+# changes from mux-rs PR #7. Swap `rev = ...` for `tag = "v0.14.0"` once
+# mux-rs publishes a tagged release that includes them.
+mux = { git = "https://github.com/2389-research/mux-rs.git", rev = "1576618856f4b51d994b6ae70af376a0fbfb6b7f" }
 infer = "0.19"
 resvg = { version = "0.47", default-features = false, features = ["text", "raster-images", "system-fonts"] }
 usvg = "0.47"

--- a/crates/barnstormer-agent/src/swarm.rs
+++ b/crates/barnstormer-agent/src/swarm.rs
@@ -12,7 +12,7 @@ use ulid::Ulid;
 
 use mux::agent::{AgentDefinition, SubAgent};
 use mux::hook::HookRegistry;
-use mux::llm::LlmClient;
+use mux::llm::{LlmClient, SystemBlock};
 
 use crate::streaming_hook::StreamingHook;
 
@@ -455,13 +455,22 @@ impl SwarmOrchestrator {
 
         let is_manager = runner.role == AgentRole::Manager;
 
-        // Create agent definition with role-specific system prompt + tool guide
-        let mut definition = AgentDefinition::new(
-            runner.role.label(),
-            full_system_prompt(&runner.role, &runner.agent_id, phase),
-        )
-        .model(model)
-        .max_iterations(10);
+        // Create agent definition with role-specific system prompt + tool guide.
+        //
+        // The system prompt (base role prompt + phase block + tool_usage_guide)
+        // is stable within a phase, so we mark it cacheable via a SystemBlock
+        // and also mark the tool definitions cacheable. Anthropic prompt
+        // caching converts repeated input from $3/M to $0.30/M on cache_read,
+        // saving ~25-35% on Manager Sonnet input across measured workloads.
+        // The legacy `system_prompt: String` positional arg is kept set so the
+        // AgentDefinition has a fallback path; mux's runner prefers
+        // `system_blocks` when non-empty.
+        let system_prompt = full_system_prompt(&runner.role, &runner.agent_id, phase);
+        let mut definition = AgentDefinition::new(runner.role.label(), system_prompt.clone())
+            .system_block(SystemBlock::cached(system_prompt))
+            .cache_tools(true)
+            .model(model)
+            .max_iterations(10);
 
         if is_manager {
             definition = definition.streaming(true);


### PR DESCRIPTION
## Summary

Enables Anthropic prompt caching on agent Sonnet calls, reducing per-call input cost by 25-35% on Manager-heavy workloads. The system prompt + tool definitions are marked cacheable via the `system_blocks` + `cache_tools(true)` API exposed by mux-rs.

Caching converts repeated input from $3/M to $0.30/M on cache_read. The system prompt + tool_usage_guide block is ~3-5K tokens and stable within a phase, so cache_read should land on call 2 and stay live for the 5-minute cache TTL.

## Live-replay measured impact

Skills Mgr workload across configurations (single Sonnet model, identical brief):

| Config | Total cost | Cache hit ratio |
|---|--:|--:|
| Uncached baseline (pre-caching) | $4.44 | 0% |
| With caching + delegation tools | **$2.75** | 57% |
| With caching, Manager only, no delegation | **$2.28** | 55% |

Caching alone consistently saves 25-35% on Manager Sonnet input across configurations, independent of which delegation tools fire.

## Changes

This PR is intentionally narrow — only the caching wiring.

`crates/barnstormer-agent/src/swarm.rs` (+15 / -6):
- Import `SystemBlock` from `mux::llm`
- At AgentDefinition construction, wrap the full system prompt (base role prompt + phase context + tool_usage_guide) in a single cached `SystemBlock` and call `.cache_tools(true)` to also cache the tool definitions. The legacy `system_prompt: String` positional arg is kept set so the AgentDefinition has a fallback path; mux's runner prefers `system_blocks` when non-empty.

`Cargo.toml` (+4 / -1):
- Pin mux dep to the merge commit of [mux-rs PR #7](https://github.com/2389-research/mux-rs/pull/7) (`1576618856f4b51d994b6ae70af376a0fbfb6b7f`) which adds the underlying cache_control API. Swap `rev = ...` for `tag = "v0.14.0"` once mux-rs publishes a tagged release including these changes.

## Dependency

Depends on [mux-rs PR #7](https://github.com/2389-research/mux-rs/pull/7) (merged into mux-rs main). No mux release tag yet — pinned to the merge commit.

## Test plan

- [x] All tests pass (`cargo test --all`)
- [x] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [x] Live verified against Anthropic API: `cache_write_tokens > 0` on first Manager call, `cache_read_tokens > 0` on subsequent calls within the 5-min TTL
- [x] Multi-configuration replay matrix confirms 25-35% Sonnet input savings

## Note

This is a focused re-do of #17 (which got bundled with the unmerged cost-telemetry stack). This PR is just the caching change against current main. The cost-telemetry/delegation-tools work will land in its own separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/barnstormer/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated the mux crate dependency from v0.13.0 to a pinned development revision. The team plans to upgrade to the official v0.14.0 release once available.

**Refactor**
- Improved agent efficiency through caching mechanisms for system prompts and tool definitions. These optimizations enhance performance and reduce redundant processing during agent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/barnstormer/pull/18)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->